### PR TITLE
New feature: possibility to customize group chat messages per job 

### DIFF
--- a/src/main/java/hudson/plugins/im/IMPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/im/IMPublisherDescriptor.java
@@ -11,8 +11,14 @@ public interface IMPublisherDescriptor {
     public static final String PARAMETERNAME_NOTIFY_CULPRITS = PREFIX + "notifyCulprits";
     public static final String PARAMETERNAME_NOTIFY_FIXERS = PREFIX + "notifyFixers";
     public static final String PARAMETERNAME_NOTIFY_UPSTREAM_COMMITTERS = PREFIX + "notifyUpstreamCommitters";
+	public static final String PARAMETERNAME_CUSTOM_GROUP_MESSAGES = PREFIX + "customGroupMessages";
+	public static final String PARAMETERNAME_CUSTOM_START_MESSAGE = PREFIX + "customStartMessage";
+	public static final String PARAMETERNAME_CUSTOM_SUCCESS_MESSAGE = PREFIX + "customSuccessMessage";
+	public static final String PARAMETERNAME_CUSTOM_FIXED_MESSAGE = PREFIX + "customFixedMessage";
+	public static final String PARAMETERNAME_CUSTOM_UNSTABLE_MESSAGE = PREFIX + "customUnstableMessage";
+	public static final String PARAMETERNAME_CUSTOM_FAILED_MESSAGE = PREFIX + "customFailedMessage";
     
-    public static final String PARAMETERVALUE_STRATEGY_DEFAULT = NotificationStrategy.STATECHANGE_ONLY.getDisplayName();;
+    public static final String PARAMETERVALUE_STRATEGY_DEFAULT = NotificationStrategy.STATECHANGE_ONLY.getDisplayName();
     public static final String[] PARAMETERVALUE_STRATEGY_VALUES = NotificationStrategy.getDisplayNames();
     public static final String PARAMETERNAME_HUDSON_LOGIN = PREFIX + "hudsonLogin";
     public static final String PARAMETERNAME_HUDSON_PASSWORD = PREFIX + "hudsonPassword";

--- a/src/main/java/hudson/plugins/im/build_notify/BuildParametersBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/BuildParametersBuildToChatNotifier.java
@@ -1,16 +1,15 @@
 package hudson.plugins.im.build_notify;
 
-import java.io.IOException;
-import java.util.List;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.plugins.im.IMPublisher;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
  * Extends {@link DefaultBuildToChatNotifier} and also prints

--- a/src/main/java/hudson/plugins/im/build_notify/CustomGroupMessageNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/CustomGroupMessageNotifier.java
@@ -1,0 +1,66 @@
+package hudson.plugins.im.build_notify;
+
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.plugins.im.IMPublisher;
+import hudson.plugins.im.tools.BuildHelper;
+import hudson.plugins.im.tools.MessageHelper;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.IOException;
+
+/**
+ * @author reynald
+ */
+public class CustomGroupMessageNotifier extends BuildToChatNotifier {
+
+	private static final String BUILD_NUMBER_TOKEN = "${BUILD_NUMBER}";
+	private static final String BUILD_URL_TOKEN = "${BUILD_URL}";
+
+	private final BuildToChatNotifier selectedNotifier;
+
+	public CustomGroupMessageNotifier(final BuildToChatNotifier selectedNotifier) {
+		this.selectedNotifier = selectedNotifier;
+	}
+
+	@Override
+	public String buildStartMessage(final IMPublisher publisher, final AbstractBuild<?, ?> build, final BuildListener listener) throws IOException, InterruptedException {
+		String message = publisher.getCustomStartMessage();
+		if (StringUtils.isEmpty(message)) {
+			message = selectedNotifier.buildStartMessage(publisher, build, listener);
+		}
+
+		return replaceTokensInMessage(message, build);
+	}
+
+	@Override
+	public String buildCompletionMessage(final IMPublisher publisher, final AbstractBuild<?, ?> build, final BuildListener listener) throws IOException, InterruptedException {
+		String message;
+		if (BuildHelper.isFix(build)) {
+			message = publisher.getCustomFixedMessage();
+		} else if (build.getResult() == Result.SUCCESS) {
+			message = publisher.getCustomSuccessMessage();
+		} else if (build.getResult() == Result.UNSTABLE) {
+			message = publisher.getCustomUnstableMessage();
+		} else if (build.getResult() == Result.FAILURE) {
+			message = publisher.getCustomFailedMessage();
+		} else {
+			message = null;
+		}
+
+		if (StringUtils.isEmpty(message)) {
+			message = selectedNotifier.buildCompletionMessage(publisher, build, listener);
+		}
+
+		return replaceTokensInMessage(message, build);
+	}
+
+	private String replaceTokensInMessage(final String message, final AbstractBuild<?, ?> build) {
+		// TODO: maybe consider using the token-macro plugin instead
+		String replacedMessage = message.replaceAll(BUILD_URL_TOKEN, MessageHelper.getBuildURL(build));
+		replacedMessage = replacedMessage.replaceAll(BUILD_NUMBER_TOKEN, String.valueOf(build.getNumber()));
+
+		return replacedMessage;
+	}
+}

--- a/src/main/resources/hudson/plugins/im/IMPublisher/config-buildToChatNotifier.jelly
+++ b/src/main/resources/hudson/plugins/im/IMPublisher/config-buildToChatNotifier.jelly
@@ -29,4 +29,29 @@ THE SOFTWARE.
   <!-- TODO: replace this with f:dropdownDescriptorSelector when depending on 1.375 or later -->
   <this:dropdownDescriptorSelector xmlns:this="/hudson/plugins/im/IMPublisher"
      title="${%Channel Notification Message}" field="buildToChatNotifier" descriptors="${allBuildToChatNotifiers}"/>
+
+  <f:optionalBlock name="${descriptor.PARAMETERNAME_CUSTOM_GROUP_MESSAGES}"
+  	title="${%Customize group chat messages}" field="customGroupMessages">
+    <f:entry title="${%Custom start message}"
+      description="${%Custom group chat start message; used only when notify build start is checked.}">
+      <f:textbox name="${descriptor.PARAMETERNAME_CUSTOM_START_MESSAGE}" field="customStartMessage"/>
+    </f:entry>
+    <f:entry title="${%Custom build success message}"
+      description="${%Custom group chat message on successful build}">
+      <f:textbox name="${descriptor.PARAMETERNAME_CUSTOM_SUCCESS_MESSAGE}" field="customSuccessMessage"/>
+    </f:entry>
+    <f:entry title="${%Custom build fixed message}"
+      description="${%Custom group chat message on fixed build}">
+      <f:textbox name="${descriptor.PARAMETERNAME_CUSTOM_FIXED_MESSAGE}" field="customFixedMessage"/>
+    </f:entry>
+    <f:entry title="${%Custom build unstable message}"
+      description="${%Custom group chat message on unstable build}">
+      <f:textbox name="${descriptor.PARAMETERNAME_CUSTOM_UNSTABLE_MESSAGE}" field="customUnstableMessage"/>
+    </f:entry>
+    <f:entry title="${%Custom build failed message}"
+      description="${%Custom group chat message on failed build}">
+      <f:textbox name="${descriptor.PARAMETERNAME_CUSTOM_FAILED_MESSAGE}" field="customFailedMessage"/>
+    </f:entry>
+
+  </f:optionalBlock>
 </j:jelly>


### PR DESCRIPTION
Hello guys,

I added a new feature to the instant-messaging plugin that allow users to override the default group chat messages per job. The code has been designed so that if a specific message has not been overridden, it will use the one from the selected channel notification message strategy. See a screenshot of the configuration page of a job here: https://skitch.com/rborer/fsmk1/custom-group-chat-message

The code also use the token-macro plugin to provide token replacements. This is quite convenient for overridden messages.

I'll also make another pull request on the jabber-plugin repository, and there are changes in this plugin that are required to enable this feature. Unfortunately I haven't patched other plugins using instant-messaging-plugin as I don't have the test infrastructure. But this change should be retro-compatible.

Any comment about this patch are welcomed.

Best regards,
Reynald
