### PR TITLE
Impersonate user instead of authenticating.

### DIFF
--- a/src/main/java/hudson/plugins/im/IMPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/im/IMPublisherDescriptor.java
@@ -15,7 +15,6 @@ public interface IMPublisherDescriptor {
     public static final String PARAMETERVALUE_STRATEGY_DEFAULT = NotificationStrategy.STATECHANGE_ONLY.getDisplayName();;
     public static final String[] PARAMETERVALUE_STRATEGY_VALUES = NotificationStrategy.getDisplayNames();
     public static final String PARAMETERNAME_HUDSON_LOGIN = PREFIX + "hudsonLogin";
-    public static final String PARAMETERNAME_HUDSON_PASSWORD = PREFIX + "hudsonPassword";
     
 	/**
 	 * Returns <code>true</code> iff the plugin is globally enabled.
@@ -70,11 +69,6 @@ public interface IMPublisherDescriptor {
      * Returns the user name needed to login into Hudson.
      */
     String getHudsonUserName();
-    
-    /**
-     * Returns the password needed to login into Hudson.
-     */
-    String getHudsonPassword();
     
     /**
      * Returns the default targets which should be used for build notification.

--- a/src/main/resources/hudson/plugins/im/IMPublisher/global-jenkinsLogin.jelly
+++ b/src/main/resources/hudson/plugins/im/IMPublisher/global-jenkinsLogin.jelly
@@ -5,9 +5,5 @@
     <f:textbox name="${descriptor.PARAMETERNAME_HUDSON_LOGIN}"
       value="${descriptor.hudsonUserName}" />
   </f:entry>
-  <f:entry title="Jenkins Password">
-    <f:password name="${descriptor.PARAMETERNAME_HUDSON_PASSWORD}"
-      value="${descriptor.hudsonPassword}" />
-  </f:entry>
   
 </j:jelly>

--- a/src/main/webapp/help-jenkins-login.html
+++ b/src/main/webapp/help-jenkins-login.html
@@ -1,5 +1,5 @@
 <div>
-    If you're using a secured Jenkins, you must specify a valid username and password for the IM bot.
+    If you're using a secured Jenkins, you must specify a valid username for the IM bot.
     Otherwise most commands won't work.<br />
     You can also use this to restrict which commands can be executed via the bot, by removing the respective
     permissions for this user.


### PR DESCRIPTION
Instead of trying to login with a username/password combination, simply
impersonate the user. Inline a copy of User.impersonate() since it seems the
plugin tries to be compatible with older Hudson versions.
