### PR TITLE
Removing yippie message

### DIFF
--- a/src/main/java/hudson/plugins/im/build_notify/SummaryOnlyBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/SummaryOnlyBuildToChatNotifier.java
@@ -29,19 +29,11 @@ public class SummaryOnlyBuildToChatNotifier extends BuildToChatNotifier {
 
     @Override
     public String buildCompletionMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
-        final StringBuilder sb;
-        if (BuildHelper.isFix(build)) {
-            sb = new StringBuilder(Messages.SummaryOnlyBuildToChatNotifier_BuildIsFixed());
-        } else {
-            sb = new StringBuilder();
-        }
-        sb.append(Messages.SummaryOnlyBuildToChatNotifier_Summary(
-                getProjectName(build), build.getDisplayName(),
-                BuildHelper.getResultDescription(build),
-                build.getTimestampString(),
-                MessageHelper.getBuildURL(build)));
-
-        return sb.toString();
+        return Messages.SummaryOnlyBuildToChatNotifier_Summary(
+               getProjectName(build), build.getDisplayName(),
+               BuildHelper.getResultDescription(build),
+               build.getTimestampString(),
+               MessageHelper.getBuildURL(build));
     }
 
     @Extension

--- a/src/main/resources/hudson/plugins/im/build_notify/Messages.properties
+++ b/src/main/resources/hudson/plugins/im/build_notify/Messages.properties
@@ -1,3 +1,2 @@
 SummaryOnlyBuildToChatNotifier.Summary=Project {0} build {1}: {2} in {3}: {4}
-SummaryOnlyBuildToChatNotifier.BuildIsFixed=Yippie, build fixed!\n
 SummaryOnlyBuildToChatNotifier.StartMessage=Starting build {0} for job {1}


### PR DESCRIPTION
Cute though the Yippie message is, after the first few times, it gets pretty annoying, in particular when using the IRC Plugin (https://wiki.jenkins-ci.org/display/JENKINS/IRC+Plugin), which means that every build-fixed message turns in to two separate messages.
