### PR TITLE
jenkinsci/instant-messaging-plugin

### DIFF
--- a/src/main/java/hudson/plugins/im/bot/BuildCommand.java
+++ b/src/main/java/hudson/plugins/im/bot/BuildCommand.java
@@ -70,7 +70,7 @@ public class BuildCommand extends AbstractTextSendingCommand {
 			    }
 			    
 			    String msg = "";
-				if (project.isInQueue()) {
+				if (project.isInQueue() && !project.isParameterized()) {
 					Queue.Item queueItem = project.getQueueItem();
 					return sender.getNickname() + ": job " + jobName + " is already in the build queue (" + queueItem.getWhy() + ")";
     			} else if (project.isDisabled()) {


### PR DESCRIPTION
The instant messaging plugin does not allow parametrized builds to queue up.

The use case is for building all SCM submissions separately. By default only one submission can queue up, while the desired functionality is that each parametrized build with different parameter values should queue separately.

An example, this starts a build and adds 9 builds into the queue (assuming parallel builds are not enabled):

$ for a in `seq 1 10`; do wget -O /dev/null --post-data="SCMid=$a" "http://hostname:8080/job/dummy_build/buildWithParameters?token=abc"; done 

If 10 similar messages ('!build dummy SCMid=1', '!build dummy SCMid=2' ... '!build dummy SCMid=10') are sent quickly to an idle job through Jabber, a build with SCMid=1 will get started and a build with SCMid=2 will be queued, the rest are ignored with message '<account>: job dummy is already in the build queue ...'.
