### PR TITLE
Adding a new notification strategy "new failure and fixed"

### DIFF
--- a/src/main/java/hudson/plugins/im/NotificationStrategy.java
+++ b/src/main/java/hudson/plugins/im/NotificationStrategy.java
@@ -2,6 +2,7 @@ package hudson.plugins.im;
 
 import hudson.model.AbstractBuild;
 import hudson.model.Result;
+import hudson.model.ResultTrend;
 import hudson.plugins.im.tools.BuildHelper;
 
 /**
@@ -56,7 +57,22 @@ public enum NotificationStrategy {
 		}
 	},
 
-    /**
+	/**
+	 * Whenever there is a new failure or a failure was fixed, a notification should be send.
+	 * Similar to #FAILURE_AND_FIXED, but repeated failures do not trigger a notification.
+ 	 */
+	NEW_FAILURE_AND_FIXED("new failure and fixed") {
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public boolean notificationWanted(final AbstractBuild<?, ?> build) {
+			ResultTrend trend = ResultTrend.getResultTrend(build);
+			return trend == ResultTrend.FAILURE || trend == ResultTrend.FIXED;
+		}
+	},
+
+	/**
 	 * Notifications should be send only if there was a change in the build
 	 * state, or this was the first build.
 	 */

--- a/src/main/resources/hudson/plugins/im/IMPublisher/notification-strategy.jelly
+++ b/src/main/resources/hudson/plugins/im/IMPublisher/notification-strategy.jelly
@@ -5,7 +5,7 @@
     IM configuration regarding notification strategies - i.e. when to notify and whom to notify.    
   </st:documentation>
 
-  <f:entry title="Notification Strategy" description="When to send notifications (all = always, failure = on any failure, failure and fixed = on failure and fixes, change = only on state change)">
+  <f:entry title="Notification Strategy" description="When to send notifications (all = always, failure = on any failure, failure and fixed = on failure and fixes, new failure and fixed = on new failure and fixes, change = only on state change)">
   <select class="setting-input" name="${descriptor.paramNames.strategy}">
        <j:forEach var="value" items="${descriptor.PARAMETERVALUE_STRATEGY_VALUES}">
           <f:option selected="${instance.strategy==value}">${value}</f:option>

--- a/src/test/java/hudson/plugins/im/NotificationStrategyTest.java
+++ b/src/test/java/hudson/plugins/im/NotificationStrategyTest.java
@@ -1,0 +1,194 @@
+package hudson.plugins.im;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Result;
+import org.junit.Test;
+
+import static hudson.model.Result.ABORTED;
+import static hudson.model.Result.FAILURE;
+import static hudson.model.Result.NOT_BUILT;
+import static hudson.model.Result.SUCCESS;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NotificationStrategyTest {
+
+  @Test
+  public void testAll() {
+    NotificationStrategy strategy = NotificationStrategy.ALL;
+    testNewFailure(strategy, true);
+    testRepeatFailure(strategy, true);
+    testFixed(strategy, true);
+    testRepeatSuccess(strategy, true);
+    testNewAborted(strategy, true);
+    testRepeatAborted(strategy, true);
+    testNewNotBuilt(strategy, true);
+    testRepeatNotBuilt(strategy, true);
+  }
+
+  @Test
+  public void testAnyFailure() {
+    NotificationStrategy strategy = NotificationStrategy.ANY_FAILURE;
+    testNewFailure(strategy, true);
+    testRepeatFailure(strategy, true);
+    testFixed(strategy, false);
+    testRepeatSuccess(strategy, false);
+
+    // ANY_FAILURE notifies on any unsuccessful build, including aborted and not built.
+    // UNSUCCESSFUL would be a better name. 
+    testNewAborted(strategy, true);
+    testRepeatAborted(strategy, true);
+    testNewNotBuilt(strategy, true);
+    testRepeatNotBuilt(strategy, true);
+  }
+
+  @Test
+  public void testFailureAndFixed() {
+    NotificationStrategy strategy = NotificationStrategy.FAILURE_AND_FIXED;
+    testNewFailure(strategy, true);
+    testRepeatFailure(strategy, true);
+    testFixed(strategy, true);
+    testRepeatSuccess(strategy, false);
+
+    // FAILURE_AND_FIXED notifies on any unsuccessful build, including aborted and not built.
+    // UNSUCCESSFUL_AND_FIXED would be a better name. 
+    testNewAborted(strategy, true);
+    testRepeatAborted(strategy, true);
+    testNewNotBuilt(strategy, true);
+    testRepeatNotBuilt(strategy, true);
+  }
+
+  @Test
+  public void testNewFailureAndFixed() {
+    NotificationStrategy strategy = NotificationStrategy.NEW_FAILURE_AND_FIXED;
+    testNewFailure(strategy, true);
+    testRepeatFailure(strategy, false);
+    testFixed(strategy, true);
+    testRepeatSuccess(strategy, false);
+    testNewAborted(strategy, false);
+    testRepeatAborted(strategy, false);
+    testNewNotBuilt(strategy, false);
+    testRepeatNotBuilt(strategy, false);
+  }
+
+  @Test
+  public void testStateChangeOnly() {
+    NotificationStrategy strategy = NotificationStrategy.STATECHANGE_ONLY;
+    testNewFailure(strategy, true);
+    testRepeatFailureStrict(strategy, false);
+    testFixed(strategy, true);
+    testRepeatSuccessStrict(strategy, false);
+    testNewAborted(strategy, true);
+    testRepeatAborted(strategy, false);
+    testNewNotBuilt(strategy, true);
+    testRepeatNotBuilt(strategy, false);
+  }
+
+  private void testNewFailure(NotificationStrategy strategy, boolean expected) {
+    // Basic success -> new failure
+    assertThat(strategy.notificationWanted(historyOf(SUCCESS, FAILURE)), equalTo(expected));
+
+    // Failure on first build.
+    assertThat(strategy.notificationWanted(historyOf(FAILURE)), equalTo(expected));
+
+    // Intermediate ABORTED and NOT_BUILT states do not affect result
+    assertThat(strategy.notificationWanted(historyOf(SUCCESS, ABORTED, FAILURE)),
+        equalTo(expected));
+    assertThat(strategy.notificationWanted(historyOf(SUCCESS, NOT_BUILT, FAILURE)),
+        equalTo(expected));
+  }
+
+  private void testRepeatFailure(NotificationStrategy strategy, boolean expected) {
+    testRepeatFailureStrict(strategy, expected);
+
+    // Intermediate ABORTED and NOT_BUILT states do not affect result
+    assertThat(strategy.notificationWanted(historyOf(SUCCESS, ABORTED, FAILURE, ABORTED, FAILURE)),
+        equalTo(expected));
+    assertThat(
+        strategy.notificationWanted(historyOf(SUCCESS, NOT_BUILT, FAILURE, NOT_BUILT, FAILURE)),
+        equalTo(expected));
+    assertThat(
+        strategy.notificationWanted(historyOf(SUCCESS, NOT_BUILT, FAILURE, ABORTED, FAILURE)),
+        equalTo(expected));
+  }
+
+  private void testRepeatFailureStrict(NotificationStrategy strategy, boolean expected) {
+    // Basic success -> new failure -> repeat failure
+    assertThat(strategy.notificationWanted(historyOf(SUCCESS, FAILURE, FAILURE)),
+        equalTo(expected));
+
+    // Repeat failure on second build.
+    assertThat(strategy.notificationWanted(historyOf(FAILURE, FAILURE)), equalTo(expected));
+  }
+
+  private void testFixed(NotificationStrategy strategy, boolean expected) {
+    // Basic failure -> fixed
+    assertThat(strategy.notificationWanted(historyOf(FAILURE, SUCCESS)), equalTo(expected));
+
+    // Intermediate ABORTED and NOT_BUILT states do not affect result
+    assertThat(strategy.notificationWanted(historyOf(FAILURE, ABORTED, SUCCESS)),
+        equalTo(expected));
+    assertThat(strategy.notificationWanted(historyOf(FAILURE, NOT_BUILT, SUCCESS)),
+        equalTo(expected));
+  }
+
+  private void testRepeatSuccess(NotificationStrategy strategy, boolean expected) {
+    testRepeatSuccessStrict(strategy, expected);
+
+    // Intermediate ABORTED and NOT_BUILT states do not affect result
+    assertThat(strategy.notificationWanted(historyOf(SUCCESS, ABORTED, SUCCESS)),
+        equalTo(expected));
+    assertThat(strategy.notificationWanted(historyOf(SUCCESS, NOT_BUILT, SUCCESS)),
+        equalTo(expected));
+  }
+
+  private void testRepeatSuccessStrict(NotificationStrategy strategy, boolean expected) {
+    // Basic failure -> fixed -> repeat success
+    assertThat(strategy.notificationWanted(historyOf(FAILURE, SUCCESS, SUCCESS)),
+        equalTo(expected));
+  }
+
+  private void testNewAborted(NotificationStrategy strategy, boolean expected) {
+    assertThat(strategy.notificationWanted(historyOf(SUCCESS, ABORTED)), equalTo(expected));
+    assertThat(strategy.notificationWanted(historyOf(FAILURE, ABORTED)), equalTo(expected));
+    assertThat(strategy.notificationWanted(historyOf(NOT_BUILT, ABORTED)), equalTo(expected));
+  }
+
+  private void testRepeatAborted(NotificationStrategy strategy, boolean expected) {
+    assertThat(strategy.notificationWanted(historyOf(SUCCESS, ABORTED, ABORTED)),
+        equalTo(expected));
+    assertThat(strategy.notificationWanted(historyOf(FAILURE, ABORTED, ABORTED)),
+        equalTo(expected));
+    assertThat(strategy.notificationWanted(historyOf(NOT_BUILT, ABORTED, ABORTED)),
+        equalTo(expected));
+  }
+
+  private void testNewNotBuilt(NotificationStrategy strategy, boolean expected) {
+    assertThat(strategy.notificationWanted(historyOf(SUCCESS, NOT_BUILT)), equalTo(expected));
+    assertThat(strategy.notificationWanted(historyOf(FAILURE, NOT_BUILT)), equalTo(expected));
+    assertThat(strategy.notificationWanted(historyOf(ABORTED, NOT_BUILT)), equalTo(expected));
+  }
+
+  private void testRepeatNotBuilt(NotificationStrategy strategy, boolean expected) {
+    assertThat(strategy.notificationWanted(historyOf(SUCCESS, NOT_BUILT, NOT_BUILT)),
+        equalTo(expected));
+    assertThat(strategy.notificationWanted(historyOf(FAILURE, NOT_BUILT, NOT_BUILT)),
+        equalTo(expected));
+    assertThat(strategy.notificationWanted(historyOf(ABORTED, NOT_BUILT, NOT_BUILT)),
+        equalTo(expected));
+  }
+
+  /** Construct a history of builds with the specified results (oldest result first). */
+  private AbstractBuild historyOf(Result... results) {
+    AbstractBuild toRet = null;
+    for (int i = 0; i < results.length; i++) {
+      AbstractBuild build = mock(AbstractBuild.class);
+      when(build.getResult()).thenReturn(results[i]);
+      when(build.getPreviousBuild()).thenReturn(toRet);
+      toRet = build;
+    }
+    return toRet;
+  }
+}


### PR DESCRIPTION
@kutzi for review

"new failure and fixed" is similar to "failure and fixed", but does not notify of repeat failures.  This is useful because when a build fails and is set to rebuild automatically, you do not want to spam IRC with repeat failures.  The new strategy is also similar to "change", but change includes aborted builds and success after an aborted build, which we don't care about.  In particular, restarting jenkins while builds are taking place aborts the current builds, then rebuilds them on startup.  Even if the build succeeds, it will notify IRC that it went from Aborted to Success.
