### PR TITLE
"Yippie!" is incorrect should be replaced with "Yippee!"

### DIFF
--- a/src/main/java/hudson/plugins/im/build_notify/BuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/BuildToChatNotifier.java
@@ -95,7 +95,7 @@ public abstract class BuildToChatNotifier implements Describable<BuildToChatNoti
      *      Any errors can be reported here.
      */
     public String fixerMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) {
-    	return "Yippie! Seems you've fixed " + getProjectName(build) + ": " + MessageHelper.getBuildURL(build);
+    	return "Yippee! Seems you've fixed " + getProjectName(build) + ": " + MessageHelper.getBuildURL(build);
     }
     
     /**

--- a/src/main/resources/hudson/plugins/im/build_notify/Messages.properties
+++ b/src/main/resources/hudson/plugins/im/build_notify/Messages.properties
@@ -1,3 +1,3 @@
 SummaryOnlyBuildToChatNotifier.Summary=Project {0} build {1}: {2} in {3}: {4}
-SummaryOnlyBuildToChatNotifier.BuildIsFixed=Yippie, build fixed!\n
+SummaryOnlyBuildToChatNotifier.BuildIsFixed=Yippee, build fixed!\n
 SummaryOnlyBuildToChatNotifier.StartMessage=Starting build {0} for job {1}


### PR DESCRIPTION
_Yipee_: an exclamation of exultation and delight

_Yippie_: a member of the Youth International Party, Abbie Hoffman's band of counter-culture activists whose political statements were made through a series of notorious pranks and gestures, such as nominating a pig for the presidency of the United States, or filing applications for permits to levitate the Pentagon and blow up Detroit's General Motors building.
