### PR TITLE
Include test results in short summary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<artifactId>instant-messaging</artifactId>
 	<name>Jenkins instant-messaging plugin</name>
-	<version>1.28</version>
+	<version>1.29-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 	<url>http://wiki.jenkins-ci.org/display/JENKINS/Instant+Messaging+Plugin</url>
 	<developers>
@@ -53,7 +53,7 @@
         <connection>scm:git:git@github.com:jenkinsci/instant-messaging-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/instant-messaging-plugin.git</developerConnection>
         <url>http://fisheye.jenkins-ci.org/browse/Jenkins/trunk/trunk/hudson/plugins/instant-messaging</url>
-      <tag>instant-messaging-1.28</tag>
+      <tag>HEAD</tag>
   </scm>    
 
     <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<artifactId>instant-messaging</artifactId>
 	<name>Jenkins instant-messaging plugin</name>
-	<version>1.28-SNAPSHOT</version>
+	<version>1.28</version>
 	<packaging>hpi</packaging>
 	<url>http://wiki.jenkins-ci.org/display/JENKINS/Instant+Messaging+Plugin</url>
 	<developers>
@@ -53,7 +53,7 @@
         <connection>scm:git:git@github.com:jenkinsci/instant-messaging-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/instant-messaging-plugin.git</developerConnection>
         <url>http://fisheye.jenkins-ci.org/browse/Jenkins/trunk/trunk/hudson/plugins/instant-messaging</url>
-      <tag>HEAD</tag>
+      <tag>instant-messaging-1.28</tag>
   </scm>    
 
     <pluginRepositories>

--- a/src/main/java/hudson/plugins/im/tools/MessageHelper.java
+++ b/src/main/java/hudson/plugins/im/tools/MessageHelper.java
@@ -49,8 +49,9 @@ public class MessageHelper {
 	 * Returns the full URL to the test details page for a given test result;
 	 */
 	public static String getTestUrl(hudson.tasks.test.TestResult result) {
-		String url = getBuildURL(result.getOwner());
-		AbstractTestResultAction action = result.getTestResultAction();
+		String buildUrl = getBuildURL(result.getOwner());
+		@SuppressWarnings("rawtypes")
+        AbstractTestResultAction action = result.getTestResultAction();
 		
 		TestObject parent = result.getParent();
 		TestResult testResultRoot = null;
@@ -62,10 +63,19 @@ public class MessageHelper {
 			parent = parent.getParent();
 		}
 		
-		url += action.getUrlName()
+		String testUrl = action.getUrlName()
 			+ (testResultRoot != null ? testResultRoot.getUrl() : "")
 			+ result.getUrl();
-		return url;
+		
+		String[] pathComponents = testUrl.split("/");
+		StringBuilder buf = new StringBuilder();
+		for (String c : pathComponents) {
+		    buf.append(Util.rawEncode(c)).append('/');
+		}
+		// remove last /
+		buf.deleteCharAt(buf.length() - 1);
+		
+        return buildUrl + buf.toString();
 	}
 
 	/**
@@ -146,7 +156,7 @@ public class MessageHelper {
 	 * Note: Unfortunately in Java 5 there is no Arrays#copyOfRange, yet.
 	 * So we have to implement it ourself.
 	 */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> T[] copyOfRange(T[] original, int from, int to) {
         int newLength = to - from;
         if (newLength < 0)
@@ -178,7 +188,7 @@ public class MessageHelper {
      * 
      * Note: copied from java 6
      */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> T[] copyOf(T[] original, int newLength) {
 		Class type = original.getClass();
         T[] copy = (type == Object[].class)

--- a/src/main/resources/hudson/plugins/im/build_notify/Messages.properties
+++ b/src/main/resources/hudson/plugins/im/build_notify/Messages.properties
@@ -1,3 +1,3 @@
-SummaryOnlyBuildToChatNotifier.Summary=Project {0} build {1}: {2} in {3}: {4}
+SummaryOnlyBuildToChatNotifier.Summary={0} {1}: {2} [{5}/{6}] ({7} failed {8}): {4}
 SummaryOnlyBuildToChatNotifier.BuildIsFixed=Yippee, build fixed!\n
 SummaryOnlyBuildToChatNotifier.StartMessage=Starting build {0} for job {1}

--- a/src/test/java/hudson/plugins/im/tools/MessageHelperTest.java
+++ b/src/test/java/hudson/plugins/im/tools/MessageHelperTest.java
@@ -1,7 +1,12 @@
 package hudson.plugins.im.tools;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import hudson.model.AbstractBuild;
 import hudson.plugins.im.tools.MessageHelper;
+import hudson.tasks.test.AbstractTestResultAction;
+import hudson.tasks.test.TestResult;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -61,5 +66,23 @@ public class MessageHelperTest {
 		
 		concat = MessageHelper.concat(a);
 		Assert.assertArrayEquals(a, concat);
+	}
+	
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
+	public void testUrlShouldBeUrlEncoded() {
+	    TestResult result = mock(TestResult.class);
+	    AbstractBuild build = mock(AbstractBuild.class);
+	    when(build.getUrl()).thenReturn("/a build");
+	    
+	    AbstractTestResultAction action = mock(AbstractTestResultAction.class);
+	    when(action.getUrlName()).thenReturn("/action");
+	    
+	    when(result.getOwner()).thenReturn(build);
+	    when(result.getTestResultAction()).thenReturn(action);
+	    when(result.getUrl()).thenReturn("/some id with spaces");
+	    
+	    String testUrl = MessageHelper.getTestUrl(result);
+	    assertEquals("null/a%20build/action/some%20id%20with%20spaces", testUrl);
 	}
 }


### PR DESCRIPTION
We (@unknown-horizons) use a slightly different output for our IRC channel reports, that you might find useful. All changes were originally made by our team member @squiddy, I just keep rebasing them onto the new changes. A sample message comparison:

**Old** format:
```Project uh-tests build #3185: SUCCESS in 1 min 13 sec: http://ci.unknown-horizons.org/job/uh-tests/3185/```

**New** format:
```uh-tests #3186: SUCCESS [153/153] (0 failed ±0): http://ci.unknown-horizons.org/job/uh-tests/3186/```

The most noteworthy feature is probably displaying the number of changes, e.g. 5 more tests failed with this build in comparison to the last build.

In total it is shorter and includes more useful information (in our opinion). Feel free to merge if you find it useful or close the PR if you don't like the output format.

Thanks for the great work on the plugin!