### PR TITLE
Support for case insensitive commands

### DIFF
--- a/src/main/java/hudson/plugins/im/bot/Bot.java
+++ b/src/main/java/hudson/plugins/im/bot/Bot.java
@@ -125,7 +125,7 @@ public class Bot implements IMMessageListener {
             String[] args = MessageHelper.extractCommandLine(payload);
             if (args.length > 0) {
                 // first word is the command name
-                String cmd = args[0];
+                String cmd = args[0].toLowerCase();
                 
                 try {
                 	BotCommand command = this.cmdsAndAliases.get(cmd);


### PR DESCRIPTION
This feature is needed because, imho, many people use an automatically capitalization in own IMs, and IM bot doesn't understand commands like "! Help", "! HELP"? etc., and this pull-request fixes it problem.
