### PR TITLE
Pipeline Support, permits downstream projects to add Pipeline Steps

### DIFF
--- a/src/main/java/hudson/plugins/im/IMPublisher.java
+++ b/src/main/java/hudson/plugins/im/IMPublisher.java
@@ -670,7 +670,8 @@ public abstract class IMPublisher extends Notifier implements BuildStep, MatrixA
         if (run instanceof AbstractBuild) {
             c = ((AbstractBuild) run).getCulprits();
         } else {
-            //the hard way, possibly a WorkflowRun
+            //the hard way, possibly a WorkflowRun.  In the future (when depending on Jenkins 2.60+),
+            // cast to RunWithSCM instead.
             try {
                 Method getCulprits = run.getClass().getMethod("getCulprits");
                 c = (Set<User>) getCulprits.invoke(run);

--- a/src/main/java/hudson/plugins/im/NotificationStrategy.java
+++ b/src/main/java/hudson/plugins/im/NotificationStrategy.java
@@ -37,7 +37,7 @@ public enum NotificationStrategy {
 		 */
 		@Override
 		public boolean notificationWanted(final Run<?, ?> run) {
-			return run.getResult() != Result.SUCCESS;
+			return !isSuccessOrInProgress(run);
 
 		}
 	},
@@ -51,10 +51,10 @@ public enum NotificationStrategy {
 		 */
 		@Override
 		public boolean notificationWanted(final Run<?, ?> run) {
-            if (run.getResult() != Result.SUCCESS) {
+            if (!isSuccessOrInProgress(run)) {
                 return true;
             }
-            return BuildHelper.isFix(run);
+            return isFix(run);
 		}
 	},
 

--- a/src/main/java/hudson/plugins/im/NotificationStrategy.java
+++ b/src/main/java/hudson/plugins/im/NotificationStrategy.java
@@ -1,10 +1,11 @@
 package hudson.plugins.im;
 
-import hudson.model.AbstractBuild;
 import hudson.model.Result;
 import hudson.model.ResultTrend;
+import hudson.model.Run;
 import hudson.plugins.im.tools.BuildHelper;
 
+import static hudson.plugins.im.tools.BuildHelper.*;
 /**
  * Represents the notification strategy.
  * 
@@ -22,7 +23,7 @@ public enum NotificationStrategy {
 		 * {@inheritDoc}
 		 */
 		@Override
-		public boolean notificationWanted(final AbstractBuild<?, ?> build) {
+		public boolean notificationWanted(final Run<?, ?> run) {
 			return true;
 		}
 	},
@@ -35,8 +36,8 @@ public enum NotificationStrategy {
 		 * {@inheritDoc}
 		 */
 		@Override
-		public boolean notificationWanted(final AbstractBuild<?, ?> build) {
-			return build.getResult() != Result.SUCCESS;
+		public boolean notificationWanted(final Run<?, ?> run) {
+			return run.getResult() != Result.SUCCESS;
 
 		}
 	},
@@ -49,11 +50,11 @@ public enum NotificationStrategy {
 		 * {@inheritDoc}
 		 */
 		@Override
-		public boolean notificationWanted(final AbstractBuild<?, ?> build) {
-            if (build.getResult() != Result.SUCCESS) {
+		public boolean notificationWanted(final Run<?, ?> run) {
+            if (run.getResult() != Result.SUCCESS) {
                 return true;
             }
-            return BuildHelper.isFix(build);
+            return BuildHelper.isFix(run);
 		}
 	},
 
@@ -66,9 +67,9 @@ public enum NotificationStrategy {
 		 * {@inheritDoc}
 		 */
 		@Override
-		public boolean notificationWanted(final AbstractBuild<?, ?> build) {
-			ResultTrend trend = ResultTrend.getResultTrend(build);
-			return trend == ResultTrend.FAILURE || trend == ResultTrend.FIXED;
+		public boolean notificationWanted(final Run<?, ?> run) {
+            ResultTrend trend = getResultTrend(run);
+            return trend == ResultTrend.FAILURE || trend == ResultTrend.FIXED;
 		}
 	},
 
@@ -82,10 +83,10 @@ public enum NotificationStrategy {
 		 * {@inheritDoc}
 		 */
 		@Override
-		public boolean notificationWanted(final AbstractBuild<?, ?> build) {
-			final AbstractBuild<?, ?> previousBuild = build.getPreviousBuild();
+		public boolean notificationWanted(final Run<?, ?> run) {
+			final Run<?, ?> previousBuild = run.getPreviousBuild();
 			return (previousBuild == null)
-					|| (build.getResult() != previousBuild.getResult());
+					|| (run.getResult() != previousBuild.getResult());
 		}
 	};
 
@@ -109,13 +110,13 @@ public enum NotificationStrategy {
 	 * Signals if the given build qualifies to send a notification according to
 	 * the current strategy.
 	 * 
-	 * @param build
+	 * @param run
 	 *            The build for which it should be decided, if notification is
 	 *            wanted or not.
 	 * @return true if, according to the given strategy, a notification should
 	 *         be sent.
 	 */
-	public abstract boolean notificationWanted(AbstractBuild<?, ?> build);
+	public abstract boolean notificationWanted(Run<?, ?> run);
 
     /**
      * Returns the name of the strategy to display in dialogs etc.

--- a/src/main/java/hudson/plugins/im/build_notify/BuildParametersBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/BuildParametersBuildToChatNotifier.java
@@ -3,11 +3,11 @@ package hudson.plugins.im.build_notify;
 import java.io.IOException;
 import java.util.List;
 
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.plugins.im.IMPublisher;
@@ -26,36 +26,36 @@ public class BuildParametersBuildToChatNotifier extends SummaryOnlyBuildToChatNo
 
     @Override
     public String buildCompletionMessage(IMPublisher publisher,
-            AbstractBuild<?, ?> build, BuildListener listener)
+            Run<?, ?> run, TaskListener listener)
             throws IOException, InterruptedException {
-        String msg = super.buildCompletionMessage(publisher, build, listener);
-        return msg + getBuildParameters(build);
+        String msg = super.buildCompletionMessage(publisher, run, listener);
+        return msg + getBuildParameters(run);
     }
 
     @Override
     public String culpritMessage(IMPublisher publisher,
-            AbstractBuild<?, ?> build, BuildListener listener) {
-        String msg = super.culpritMessage(publisher, build, listener);
-        return msg + getBuildParameters(build);
+            Run<?, ?> run, TaskListener listener) {
+        String msg = super.culpritMessage(publisher, run, listener);
+        return msg + getBuildParameters(run);
     }
 
     @Override
     public String suspectMessage(IMPublisher publisher,
-            AbstractBuild<?, ?> build, BuildListener listener,
+            Run<?, ?> run, TaskListener listener,
             boolean firstFailure) {
-        String msg = super.suspectMessage(publisher, build, listener, firstFailure);
-        return msg + getBuildParameters(build);
+        String msg = super.suspectMessage(publisher, run, listener, firstFailure);
+        return msg + getBuildParameters(run);
     }
 
     @Override
     public String upstreamCommitterMessage(IMPublisher publisher,
-            AbstractBuild<?, ?> build, BuildListener listener,
-            AbstractBuild<?, ?> upstreamBuild) {
+            Run<?, ?> build, TaskListener listener,
+            Run<?, ?> upstreamBuild) {
         String msg = super.upstreamCommitterMessage(publisher, build, listener, upstreamBuild);
         return msg + getBuildParameters(build);
     }
 
-    private CharSequence getBuildParameters(AbstractBuild<?, ?> build) {
+    private CharSequence getBuildParameters(Run<?, ?> build) {
 
         ParametersAction parametersAction = build.getAction(ParametersAction.class);
 

--- a/src/main/java/hudson/plugins/im/build_notify/BuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/BuildToChatNotifier.java
@@ -6,12 +6,13 @@ import hudson.model.BuildListener;
 import hudson.model.Describable;
 import hudson.model.AbstractBuild;
 import hudson.model.Hudson;
-import hudson.model.ResultTrend;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.plugins.im.IMPublisher;
 import hudson.plugins.im.tools.MessageHelper;
 
 import java.io.IOException;
-
+import static hudson.plugins.im.tools.BuildHelper.*;
 /**
  * Controls the exact messages to be sent to a chat upon start/completion of a build.
  *
@@ -35,36 +36,31 @@ public abstract class BuildToChatNotifier implements Describable<BuildToChatNoti
 
     /**
      * Calculates the message to send out to a chat when the specified build is completed.
-     *
-     * @param publisher
+     *  @param publisher
      *      The publisher that's driving this. Never null.
-     * @param build
+     * @param run
      *      The build that just completed. Never null.
      * @param listener
-     *      Any errors can be reported here.
      */
-    public abstract String buildCompletionMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener)
+    public abstract String buildCompletionMessage(IMPublisher publisher, Run<?, ?> run, TaskListener listener)
             throws IOException,  InterruptedException;
     
     /**
      * Calculates the message to send out to a committer of a broken build.
-     * 
-     * @param publisher
+     *  @param publisher
      *      The publisher that's driving this. Never null.
-     * @param build
+     * @param run
      *      The build that just completed. Never null.
      * @param listener
-     *      Any errors can be reported here.
+ *      Any errors can be reported here.
      * @param firstFailure
-     *      True if this is the first failed build, false if it's a 'still-failing' build
      */
-    public String suspectMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener,
-    		boolean firstFailure) {
+    public String suspectMessage(IMPublisher publisher, Run<?, ?> run, TaskListener listener, boolean firstFailure) {
     	if (firstFailure) {
-    		return "Oh no! You're suspected of having broken " + getProjectName(build) + ": " + MessageHelper.getBuildURL(build);
+    		return "Oh no! You're suspected of having broken " + getProjectName(run) + ": " + MessageHelper.getBuildURL(run);
     	} else {
-    		return "Build " + getProjectName(build) +
-    	    	" is " + ResultTrend.getResultTrend(build).getID() + ": " + MessageHelper.getBuildURL(build);
+    		return "Build " + getProjectName(run) +
+    	    	" is " + getResultTrend(run).getID() + ": " + MessageHelper.getBuildURL(run);
     	}
     }
     
@@ -72,16 +68,14 @@ public abstract class BuildToChatNotifier implements Describable<BuildToChatNoti
      * Calculates the message to send out to a 'culprit' of a broken build.
      * I.e. a committer to a previous build which was broken and all builds since then
      * have been broken.
-     *
-     * @param publisher
+     *  @param publisher
      *      The publisher that's driving this. Never null.
-     * @param build
+     * @param run
      *      The build that just completed. Never null.
      * @param listener
-     *      Any errors can be reported here.
      */
-    public String culpritMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) {
-    	return "You're still being suspected of having broken " + getProjectName(build) + ": " + MessageHelper.getBuildURL(build);
+    public String culpritMessage(IMPublisher publisher, Run<?, ?> run, TaskListener listener) {
+    	return "You're still being suspected of having broken " + getProjectName(run) + ": " + MessageHelper.getBuildURL(run);
     }
     
     /**
@@ -89,33 +83,31 @@ public abstract class BuildToChatNotifier implements Describable<BuildToChatNoti
      * 
      * @param publisher
      *      The publisher that's driving this. Never null.
-     * @param build
+     * @param run
      *      The build that just completed. Never null.
      * @param listener
      *      Any errors can be reported here.
      */
-    public String fixerMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) {
-    	return "Yippee! Seems you've fixed " + getProjectName(build) + ": " + MessageHelper.getBuildURL(build);
+    public String fixerMessage(IMPublisher publisher, Run<?, ?> run, TaskListener listener) {
+    	return "Yippee! Seems you've fixed " + getProjectName(run) + ": " + MessageHelper.getBuildURL(run);
     }
     
     /**
      * Calculates the message to send out to a committer of an upstream build
      * if this build is broken.
-     * 
-     * @param publisher
+     *  @param publisher
      *      The publisher that's driving this. Never null.
-     * @param build
+     * @param run
      *      The build that just completed. Never null.
      * @param listener
-     *      Any errors can be reported here.
+ *      Any errors can be reported here.
      * @param upstreamBuild
-     * 	    The upstream build
      */
-    public String upstreamCommitterMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener,
-    		AbstractBuild<?, ?> upstreamBuild) {
+    public String upstreamCommitterMessage(IMPublisher publisher, Run<?, ?> run, TaskListener listener,
+            Run<?, ?> upstreamBuild) {
     	return "Attention! Your change in " + getProjectName(upstreamBuild)
         	+ ": " + MessageHelper.getBuildURL(upstreamBuild)
-        	+ " *might* have broken the downstream job " + getProjectName(build) + ": " + MessageHelper.getBuildURL(build)	
+        	+ " *might* have broken the downstream job " + getProjectName(run) + ": " + MessageHelper.getBuildURL(run)
         	+ "\nPlease have a look!";
     }
 

--- a/src/main/java/hudson/plugins/im/build_notify/DefaultBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/DefaultBuildToChatNotifier.java
@@ -5,12 +5,17 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Result;
 import hudson.model.ResultTrend;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.plugins.im.IMPublisher;
+import hudson.plugins.im.tools.BuildHelper;
+import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.Entry;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
-
+import java.util.List;
+import static hudson.plugins.im.tools.BuildHelper.*;
 /**
  * {@link BuildToChatNotifier} that maintains the traditional behaviour of {@link IMPublisher}.
  *
@@ -28,7 +33,7 @@ public class DefaultBuildToChatNotifier extends SummaryOnlyBuildToChatNotifier {
         AbstractBuild<?, ?> previousBuild = build.getPreviousBuild();
         if (previousBuild != null && !previousBuild.isBuilding()) {
             sb.append(" (previous build: ")
-                .append(ResultTrend.getResultTrend(previousBuild).getID());
+                .append(getResultTrend(previousBuild).getID());
 
             
             if (previousBuild.getResult().isWorseThan(Result.SUCCESS)) {
@@ -46,17 +51,21 @@ public class DefaultBuildToChatNotifier extends SummaryOnlyBuildToChatNotifier {
     }
 
     @Override
-    public String buildCompletionMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
-        StringBuilder sb = new StringBuilder(super.buildCompletionMessage(publisher,build,listener));
+    public String buildCompletionMessage(IMPublisher publisher, Run<?, ?> run, TaskListener listener) throws IOException, InterruptedException {
+        StringBuilder sb = new StringBuilder(super.buildCompletionMessage(publisher, run,listener));
 
-        if (!build.getChangeSet().isEmptySet()) {
-            boolean hasManyChangeSets = build.getChangeSet().getItems().length > 1;
-            for (Entry entry : build.getChangeSet()) {
-                sb.append("\n");
-                if (hasManyChangeSets) {
-                    sb.append("* ");
+        List<ChangeLogSet<ChangeLogSet.Entry>> changelogSets = BuildHelper.getChangelogSets(run, listener);
+
+        for (ChangeLogSet<ChangeLogSet.Entry> set : changelogSets) {
+            if (!set.isEmptySet()) {
+                boolean hasManyChangeSets = set.getItems().length > 1;
+                for (Entry entry : set) {
+                    sb.append("\n");
+                    if (hasManyChangeSets) {
+                        sb.append("* ");
+                    }
+                    sb.append(entry.getAuthor()).append(": ").append(entry.getMsg());
                 }
-                sb.append(entry.getAuthor()).append(": ").append(entry.getMsg());
             }
         }
 

--- a/src/main/java/hudson/plugins/im/build_notify/ExtraMessageOnlyBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/ExtraMessageOnlyBuildToChatNotifier.java
@@ -1,0 +1,47 @@
+package hudson.plugins.im.build_notify;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.ResultTrend;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.im.IMPublisher;
+import hudson.plugins.im.tools.MessageHelper;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+import static hudson.plugins.im.tools.BuildHelper.getProjectName;
+import static hudson.plugins.im.tools.BuildHelper.getResultTrend;
+import static hudson.plugins.im.tools.BuildHelper.isFix;
+
+/**
+ * {@link BuildToChatNotifier} that skips status and everything except extraMessage.
+ * This is probably most useful as a pipeline step.
+ *
+ */
+public class ExtraMessageOnlyBuildToChatNotifier extends BuildToChatNotifier {
+    @DataBoundConstructor
+    public ExtraMessageOnlyBuildToChatNotifier() {
+    }
+
+    @Override
+    public String buildStartMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
+        return Messages.ExtraMessageOnlyBuildToChatNotifier_StartMessage(
+                build.getDisplayName(),getProjectName(build), publisher.getExtraMessage());
+    }
+
+    @Override
+    public String buildCompletionMessage(IMPublisher publisher, Run<?, ?> run, TaskListener listener) throws IOException, InterruptedException {
+        return Messages.ExtraMessageOnlyBuildToChatNotifier_Message(
+                getProjectName(run), run.getDisplayName(), publisher.getExtraMessage());
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BuildToChatNotifierDescriptor {
+        public String getDisplayName() {
+            return "Extra Message Only";
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/im/build_notify/PrintFailingTestsBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/PrintFailingTestsBuildToChatNotifier.java
@@ -5,11 +5,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
 import hudson.plugins.im.IMPublisher;
 import hudson.plugins.im.tools.MessageHelper;
 import hudson.tasks.junit.CaseResult;
@@ -31,39 +31,39 @@ public class PrintFailingTestsBuildToChatNotifier extends
 
 	@Override
 	public String buildCompletionMessage(IMPublisher publisher,
-			AbstractBuild<?, ?> build, BuildListener listener)
+            Run<?, ?> run, TaskListener listener)
 			throws IOException, InterruptedException {
-		String msg = super.buildCompletionMessage(publisher, build, listener);
-		return msg + getFailedTestsReport(build);
+		String msg = super.buildCompletionMessage(publisher, run, listener);
+		return msg + getFailedTestsReport(run);
 	}
 	
 	
 	
 	@Override
 	public String culpritMessage(IMPublisher publisher,
-			AbstractBuild<?, ?> build, BuildListener listener) {
-		String msg = super.culpritMessage(publisher, build, listener);
-		return msg + getFailedTestsReport(build);
+            Run<?, ?> run, TaskListener listener) {
+		String msg = super.culpritMessage(publisher, run, listener);
+		return msg + getFailedTestsReport(run);
 	}
 
 	@Override
 	public String suspectMessage(IMPublisher publisher,
-			AbstractBuild<?, ?> build, BuildListener listener,
-			boolean firstFailure) {
-		String msg = super.suspectMessage(publisher, build, listener, firstFailure);
-		return msg + getFailedTestsReport(build);
+            Run<?, ?> run, TaskListener listener,
+            boolean firstFailure) {
+		String msg = super.suspectMessage(publisher, run, listener, firstFailure);
+		return msg + getFailedTestsReport(run);
 	}
 
 	@Override
 	public String upstreamCommitterMessage(IMPublisher publisher,
-			AbstractBuild<?, ?> build, BuildListener listener,
-			AbstractBuild<?, ?> upstreamBuild) {
+            Run<?, ?> build, TaskListener listener,
+            Run<?, ?> upstreamBuild) {
 		String msg = super
 				.upstreamCommitterMessage(publisher, build, listener, upstreamBuild);
 		return msg + getFailedTestsReport(build);
 	}
 
-	private CharSequence getFailedTestsReport(AbstractBuild<?, ?> build) {
+	private CharSequence getFailedTestsReport(Run<?, ?> build) {
 		
 		AbstractTestResultAction testResultAction = build.getAction(AbstractTestResultAction.class);
 		if (testResultAction == null || testResultAction.getFailCount() == 0) {

--- a/src/main/java/hudson/plugins/im/build_notify/SummaryOnlyBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/SummaryOnlyBuildToChatNotifier.java
@@ -4,6 +4,8 @@ import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.ResultTrend;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.plugins.im.IMPublisher;
 import hudson.plugins.im.tools.BuildHelper;
 import hudson.plugins.im.tools.MessageHelper;
@@ -25,22 +27,24 @@ public class SummaryOnlyBuildToChatNotifier extends BuildToChatNotifier {
 
     @Override
     public String buildStartMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
-        return Messages.SummaryOnlyBuildToChatNotifier_StartMessage(build.getDisplayName(),getProjectName(build));
+        return Messages.SummaryOnlyBuildToChatNotifier_StartMessage(build.getDisplayName(),getProjectName(build), publisher.getExtraMessage());
     }
 
     @Override
-    public String buildCompletionMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
+    public String buildCompletionMessage(IMPublisher publisher, Run<?, ?> run, TaskListener listener) throws IOException, InterruptedException {
         final StringBuilder sb;
-        if (BuildHelper.isFix(build)) {
+        if (isFix(run)) {
             sb = new StringBuilder(Messages.SummaryOnlyBuildToChatNotifier_BuildIsFixed());
         } else {
             sb = new StringBuilder();
         }
+        ResultTrend result = getResultTrend(run);
         sb.append(Messages.SummaryOnlyBuildToChatNotifier_Summary(
-                getProjectName(build), build.getDisplayName(),
-                ResultTrend.getResultTrend(build).getID(),
-                build.getTimestampString(),
-                MessageHelper.getBuildURL(build)));
+                getProjectName(run), run.getDisplayName(),
+                result.getID(),
+                run.getTimestampString(),
+                MessageHelper.getBuildURL(run),
+                publisher.getExtraMessage()));
 
         return sb.toString();
     }

--- a/src/main/java/hudson/plugins/im/config/ParameterNames.java
+++ b/src/main/java/hudson/plugins/im/config/ParameterNames.java
@@ -16,7 +16,11 @@ public abstract class ParameterNames {
     public String getNotifyStart() {
         return getPrefix() + "notifyStart";
     }
-    
+
+    public String getExtraMessage() {
+        return getPrefix() + "extraMessage";
+    }
+
     public String getNotifySuspects() {
         return getPrefix() + "notifySuspects";
     }

--- a/src/main/java/hudson/plugins/im/tools/BuildHelper.java
+++ b/src/main/java/hudson/plugins/im/tools/BuildHelper.java
@@ -4,6 +4,17 @@ import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.Result;
 import hudson.model.ResultTrend;
+import hudson.model.TaskListener;
+import hudson.model.User;
+import hudson.scm.ChangeLogSet;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Helper class to work with Hudson builds.
@@ -70,6 +81,31 @@ public class BuildHelper {
 			return previousResult != null && previousResult.isWorseThan(Result.SUCCESS);
         }
         return false;
+    }
+
+
+    /**
+     * Supports calling ResultTrend.getResultTrend() before there is a result
+     * which would otherwise result in an NPE
+     * @return NOT_BUILT if result isn't set (yet)
+     */
+    public static ResultTrend getResultTrend(Run<?, ?> run) {
+        if (run.getResult() == null) {
+            return ResultTrend.NOT_BUILT;
+        }
+        return ResultTrend.getResultTrend(run);
+    }
+
+    /**
+     * This version uses ResultTrend
+     *
+     * Returns true if this build represents a 'fix'.
+     * I.e. it is the first successful build after previous
+     * 'failed' and/or 'unstable' builds.
+     * Ignores 'aborted' and 'not built' builds.
+     */
+    public static boolean isFix(Run<?, ?> run) {
+        return getResultTrend(run) == ResultTrend.FIXED;
     }
 
     /**
@@ -188,7 +224,65 @@ public class BuildHelper {
      * Returns the name of the project the build belongs to in a human readable
      * format.
      */
-    public static String getProjectName(AbstractBuild<?, ?> build) {
-    	return build.getProject().getFullDisplayName();
+    public static String getProjectName(Run<?, ?> run) {
+    	return run.getParent().getFullDisplayName();
     }
+
+
+    /**
+     * Supports retrieving changelogsets from both AbstractBuild and from generic Run subclasses
+     * @param run
+     * @param listener
+     * @return
+     */
+    public static List<ChangeLogSet<ChangeLogSet.Entry>> getChangelogSets(Run<?, ?> run, TaskListener listener) {
+        if (run instanceof AbstractBuild) {
+            return getChangelogSetsFromAbstractBuild((AbstractBuild) run);
+        }
+        return getChangelogSetsTheHardWay(run, listener);
+    }
+
+
+    public static Set<User> getCommitters(Run<?, ?> run, TaskListener listener) {
+        List<ChangeLogSet<ChangeLogSet.Entry>> changelogSets = getChangelogSets(run, listener);
+        final Set<User> users = new HashSet<>();
+        for (ChangeLogSet set : changelogSets) {
+            addChangeSetUsers(set, users);
+        }
+        return users;
+    }
+
+    public static List<ChangeLogSet<ChangeLogSet.Entry>> getChangelogSetsFromAbstractBuild(AbstractBuild build) {
+        List<ChangeLogSet<ChangeLogSet.Entry>> result = new LinkedList();
+        result.add(build.getChangeSet());
+        return result;
+    }
+
+
+    public static List<ChangeLogSet<ChangeLogSet.Entry>> getChangelogSetsTheHardWay(final Run<?, ?> run, TaskListener listener) {
+        final List<ChangeLogSet<ChangeLogSet.Entry>> result = Collections.emptyList();
+        // NOTE: code based on email-ext RecipientProviderUtilities.java, may not be needed down the line
+        try {
+            Method getChangeSets = run.getClass().getMethod("getChangeSets");
+            if (List.class.isAssignableFrom(getChangeSets.getReturnType())) {
+                result.addAll((List<ChangeLogSet<ChangeLogSet.Entry>>) getChangeSets.invoke(run));
+            }
+        } catch (NoSuchMethodException  | InvocationTargetException | IllegalAccessException e) {
+            listener.error("Exception getting changesets for %s: %s", run, e);
+        }
+        return result;
+    }
+
+    /**
+     * Stolen from email-ext
+     */
+    private static void addChangeSetUsers(ChangeLogSet<?> changeLogSet, Set<User> users) {
+        final Set<User> changeAuthors = new HashSet<User>();
+        for (final ChangeLogSet.Entry change : changeLogSet) {
+            final User changeAuthor = change.getAuthor();
+            changeAuthors.add(changeAuthor);
+        }
+        users.addAll(changeAuthors);
+    }
+
 }

--- a/src/main/java/hudson/plugins/im/tools/MessageHelper.java
+++ b/src/main/java/hudson/plugins/im/tools/MessageHelper.java
@@ -6,10 +6,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import hudson.model.Run;
 import org.apache.commons.lang.StringUtils;
 
 import hudson.Util;
-import hudson.model.AbstractBuild;
 import hudson.model.Hudson;
 import hudson.tasks.test.TestObject;
 import hudson.tasks.junit.TestResult;
@@ -28,7 +28,7 @@ public class MessageHelper {
 	/**
 	 * Returns the full URL to the build details page for a given build.
 	 */
-	public static String getBuildURL(AbstractBuild<?, ?> build) {
+	public static String getBuildURL(Run<?, ?> run) {
 		// The hudson's base url
 	    final StringBuilder builder;
 	    if (Hudson.getInstance() != null) {
@@ -40,7 +40,7 @@ public class MessageHelper {
 
 		// The build's url, escaped for project with space or other specials
 		// characters
-		builder.append(Util.encode(build.getUrl()));
+		builder.append(Util.encode(run.getUrl()));
 
 		return builder.toString();
 	}

--- a/src/main/java/hudson/plugins/im/tools/MessageHelper.java
+++ b/src/main/java/hudson/plugins/im/tools/MessageHelper.java
@@ -24,11 +24,14 @@ import hudson.tasks.test.AbstractTestResultAction;
 public class MessageHelper {
 	private final static Pattern SPACE_PATTERN = Pattern.compile("\\s");
 	private final static String QUOTE = "\"";
-	
+
 	/**
 	 * Returns the full URL to the build details page for a given build.
 	 */
 	public static String getBuildURL(Run<?, ?> run) {
+		if (run == null) {
+			return "?";
+		}
 		// The hudson's base url
 	    final StringBuilder builder;
 	    if (Hudson.getInstance() != null) {

--- a/src/main/resources/hudson/plugins/im/IMPublisher/notification-strategy.jelly
+++ b/src/main/resources/hudson/plugins/im/IMPublisher/notification-strategy.jelly
@@ -12,6 +12,11 @@
        </j:forEach>
   </select>
   </f:entry>
+
+  <f:entry title="Extra Message" description="Additional arbitrary text to add to the notification">
+    <f:textbox name="${descriptor.paramNames.extraMessage}" value="${instance.extraMessage}" />
+  </f:entry>
+
   <f:entry title="Notify on build starts" description="Whether to send notifications to channels when a build starts">
     <f:checkbox name="${descriptor.paramNames.notifyStart}" checked="${instance.notifyOnStart}"/>
   </f:entry>

--- a/src/main/resources/hudson/plugins/im/build_notify/Messages.properties
+++ b/src/main/resources/hudson/plugins/im/build_notify/Messages.properties
@@ -1,3 +1,5 @@
-SummaryOnlyBuildToChatNotifier.Summary=Project {0} build {1}: {2} in {3}: {4}
+SummaryOnlyBuildToChatNotifier.Summary=Project {0} build {1}: {2} in {3}: {4} {5}
 SummaryOnlyBuildToChatNotifier.BuildIsFixed=Yippee, build fixed!\n
-SummaryOnlyBuildToChatNotifier.StartMessage=Starting build {0} for job {1}
+SummaryOnlyBuildToChatNotifier.StartMessage=Starting build {0} for job {1} {2}
+ExtraMessageOnlyBuildToChatNotifier.StartMessage=Starting build {0} for job {1}: {2}
+ExtraMessageOnlyBuildToChatNotifier.Message=Project {0} build {1}: {2}

--- a/src/test/java/hudson/plugins/im/IMPublisherTest.java
+++ b/src/test/java/hudson/plugins/im/IMPublisherTest.java
@@ -148,7 +148,7 @@ public class IMPublisherTest {
      */
     @Test
     public void testIncludeUpstreamCulprits() throws MessagingException, InterruptedException {
-        Set<User> recipients = this.imPublisher.getNearestUpstreamCommitters(this.build).keySet();
+        Set<User> recipients = this.imPublisher.getNearestUpstreamCommitters(this.build, listener).keySet();
         
         assertEquals(recipients.toString(), 2, recipients.size());
         

--- a/src/test/java/hudson/plugins/im/tools/BuildHelperTest.java
+++ b/src/test/java/hudson/plugins/im/tools/BuildHelperTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import hudson.model.FreeStyleBuild;
 import hudson.model.Result;
+import hudson.model.ResultTrend;
 import hudson.plugins.im.tools.BuildHelper.ExtResult;
 
 import org.junit.Test;
@@ -24,40 +25,40 @@ public class BuildHelperTest {
             
             // non non-successful build can ever be a fix:
             when(build.getResult()).thenReturn(Result.ABORTED);
-            assertFalse(BuildHelper.isFix(build));
+            assertFalse(ResultTrend.FIXED == ResultTrend.getResultTrend(build));
             
             when(build.getResult()).thenReturn(Result.NOT_BUILT);
-            assertFalse(BuildHelper.isFix(build));
+            assertFalse(ResultTrend.FIXED == ResultTrend.getResultTrend(build));
             
             when(build.getResult()).thenReturn(Result.UNSTABLE);
-            assertFalse(BuildHelper.isFix(build));
+            assertFalse(ResultTrend.FIXED == ResultTrend.getResultTrend(build));
             
             when(build.getResult()).thenReturn(Result.FAILURE);
-            assertFalse(BuildHelper.isFix(build));
+            assertFalse(ResultTrend.FIXED == ResultTrend.getResultTrend(build));
             
             // only a success can be a fix
             when(build.getResult()).thenReturn(Result.SUCCESS);
-            assertTrue(BuildHelper.isFix(build));
+            assertTrue(ResultTrend.FIXED == ResultTrend.getResultTrend(build));
         }
         
         {
             // a success without a previous failure cannot be a fix:
             FreeStyleBuild build = mock(FreeStyleBuild.class);
             when(build.getResult()).thenReturn(Result.SUCCESS);
-            assertFalse(BuildHelper.isFix(build));
+            assertFalse(ResultTrend.FIXED == ResultTrend.getResultTrend(build));
         }
         
         {
             // ABORTED doesn't count as failure
             FreeStyleBuild build = mock(FreeStyleBuild.class);
             when(build.getResult()).thenReturn(Result.ABORTED);
-            assertFalse(BuildHelper.isFix(build));
+            assertFalse(ResultTrend.FIXED == ResultTrend.getResultTrend(build));
 
             FreeStyleBuild nextBuild = mock(FreeStyleBuild.class);
             when(nextBuild.getResult()).thenReturn(Result.SUCCESS);
             when(nextBuild.getPreviousBuild()).thenReturn(build);
             
-            assertFalse(BuildHelper.isFix(nextBuild));
+            assertFalse(ResultTrend.FIXED == ResultTrend.getResultTrend(nextBuild));
             
             // but if there was a unstable/failing build somewhere before,
             // it is a fix again
@@ -71,7 +72,7 @@ public class BuildHelperTest {
             
             when(anotherAborted.getPreviousBuild()).thenReturn(anUnstableBuild);
             
-            assertTrue(BuildHelper.isFix(nextBuild));
+            assertTrue(ResultTrend.FIXED == ResultTrend.getResultTrend(nextBuild));
         }
     }
     


### PR DESCRIPTION
Although the actual Step implementation belongs downstream (eg Jabber Plugin), changes here allow this code to work with Run instead of AbstractBuild.  Some job traversal logic is not fully supported due to complexity of Pipeline job relationships.

See [JENKINS-36826](https://issues.jenkins-ci.org/browse/JENKINS-36826?focusedCommentId=321407&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-321407)

#### Additional changes:
* Supporting "extra message" (arbitrary text added to the IM).
* New notifier (ExtraMessageOnly) because the pipeline step can be used multiple times and for multiple things.
* Defaulting build result to NOT_BUILT if null because in pipeline the step will often run before the build result is set. 

I have tested this to some extent with the Jabber Plugin (separate PR pending) for both AbstractBuild and Pipelines.  I don't use the other plugins.

Comments welcome. 