### PR TITLE
JENKINS-55755 plus support for printing URLs of currently running pipeline builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,23 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Jenkins pipeline support below -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>2.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>2.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.8</version>
+        </dependency>
+
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,30 +1,30 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.jvnet.hudson.plugins</groupId>
-		<artifactId>instant-messaging-parent</artifactId>
-		<version>1.27</version>
-		<relativePath>../instant-messaging-parent-plugin/pom.xml</relativePath>
-	</parent>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jvnet.hudson.plugins</groupId>
+        <artifactId>instant-messaging-parent</artifactId>
+        <version>1.27</version>
+        <relativePath>../instant-messaging-parent-plugin/pom.xml</relativePath>
+    </parent>
 
-	<artifactId>instant-messaging</artifactId>
-	<name>Jenkins instant-messaging plugin</name>
-	<version>1.36-SNAPSHOT</version>
-	<packaging>hpi</packaging>
-	<url>http://wiki.jenkins-ci.org/display/JENKINS/Instant+Messaging+Plugin</url>
-	<developers>
-		<developer>
-			<id>kutzi</id>
-			<name>Christoph Kutzinski</name>
-			<email>kutzi@gmx.de</email>
-			<timezone>1</timezone>
-		</developer>
+    <artifactId>instant-messaging</artifactId>
+    <name>Jenkins instant-messaging plugin</name>
+    <version>1.36-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <url>http://wiki.jenkins-ci.org/display/JENKINS/Instant+Messaging+Plugin</url>
+    <developers>
+        <developer>
+            <id>kutzi</id>
+            <name>Christoph Kutzinski</name>
+            <email>kutzi@gmx.de</email>
+            <timezone>1</timezone>
+        </developer>
         <developer>
           <id>kohsuke</id>
           <name>Kohsuke Kawaguchi</name>
           <email>kk@kohsuke.org</email>
         </developer>
-	</developers>
+    </developers>
 
     <licenses>
         <license>
@@ -32,38 +32,60 @@
             <comments>All source code is under the MIT license.</comments>
         </license>
     </licenses>
-    
+
     <build>
-    	<pluginManagement>
-    		<plugins>
-	    		<plugin>
-	        		<artifactId>maven-javadoc-plugin</artifactId>
-	        		<configuration>
-	        			<skip>true</skip>
-	        		</configuration>
-		      </plugin>
-	    	</plugins>
-    	</pluginManagement>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+              </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
-    
+
     <dependencies>
-    	<dependency>
-        	<groupId>org.jenkins-ci.plugins</groupId>
-        	<artifactId>mailer</artifactId>
-        	<version>1.7</version>
-        	<!-- TODO: should be transformed into a optional dependency -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>mailer</artifactId>
+            <version>1.7</version>
+            <!-- TODO: should be transformed into a optional dependency -->
         </dependency>
         <dependency>
-        	<groupId>org.jenkins-ci.plugins</groupId>
-        	<artifactId>matrix-project</artifactId>
-        	<version>1.4</version>
-        	<!-- TODO: should be transformed into a optional dependency -->
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.4</version>
+            <!-- TODO: should be transformed into a optional dependency -->
         </dependency>
         <dependency>
-        	<groupId>org.jenkins-ci.plugins</groupId>
-        	<artifactId>junit</artifactId>
-        	<version>1.7</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit</artifactId>
+            <version>1.7</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>maven-plugin</artifactId>
+            <!-- needs hudson.model.User with getById() -->
+            <version>2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-war</artifactId>
+            <type>war</type>
+            <!-- needs hudson.model.User with getById() -->
+            <version>2.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-core</artifactId>
+            <!-- needs hudson.model.User with getById() -->
+            <version>2.3</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
@@ -71,20 +93,20 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
-    
+
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
             <url>http://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
-    
+
     <scm>
         <connection>scm:git:git@github.com:jenkinsci/instant-messaging-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/instant-messaging-plugin.git</developerConnection>
         <url>http://fisheye.jenkins-ci.org/browse/Jenkins/trunk/trunk/hudson/plugins/instant-messaging</url>
       <tag>HEAD</tag>
-  </scm>    
+    </scm>
 
     <pluginRepositories>
         <pluginRepository>
@@ -92,5 +114,5 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-</project>  
+</project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,27 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                   <artifactId>maven-checkstyle-plugin</artifactId>
+                   <version>3.0.0</version>
+                   <configuration>
+                     <configLocation>${basedir}/checkstyle.xml</configLocation>
+                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                     <sourceDirectories>
+                       <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                     </sourceDirectories>
+                     <testSourceDirectories>
+                       <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+                     </testSourceDirectories>
+                   </configuration>
+                   <executions>
+                     <execution>
+                       <goals>
+                         <goal>check</goal>
+                       </goals>
+                     </execution>
+                   </executions>
+                </plugin>
+                <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
                         <skip>true</skip>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <connection>scm:git:git@github.com:jenkinsci/instant-messaging-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/instant-messaging-plugin.git</developerConnection>
         <url>http://fisheye.jenkins-ci.org/browse/Jenkins/trunk/trunk/hudson/plugins/instant-messaging</url>
-      <tag>HEAD</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <pluginRepositories>
@@ -153,4 +153,3 @@
         </pluginRepository>
     </pluginRepositories>
 </project>
-

--- a/src/main/java/hudson/plugins/im/bot/CurrentlyBuildingCommand.java
+++ b/src/main/java/hudson/plugins/im/bot/CurrentlyBuildingCommand.java
@@ -25,6 +25,8 @@ import java.util.regex.Pattern;
 
 import jenkins.model.Jenkins;
 
+import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution.PlaceholderTask;
+
 /**
  * CurrentlyBuilding command for instant messaging plugin.
  *
@@ -130,6 +132,12 @@ public class CurrentlyBuildingCommand extends BotCommand {
                         item = (Item) task;
                     }
 
+                    PlaceholderTask placeholderTask = null;
+                    if (task instanceof PlaceholderTask) {
+                        // e.g. a part of pipeline
+                        placeholderTask = (PlaceholderTask) task;
+                    }
+
                     StringBuffer msgLine = new StringBuffer();
 
                     msgLine.append(computer.getDisplayName());
@@ -163,6 +171,10 @@ public class CurrentlyBuildingCommand extends BotCommand {
                         if (currentExecutableBuild != null) {
                             if (cbDebug) { msgLine.append(" URL:currExec= "); }
                             relativeUrl = currentExecutableBuild.getUrl();
+                        }
+                        if ((relativeUrl == null || relativeUrl.equals("")) && placeholderTask != null) {
+                            if (cbDebug) { msgLine.append(" URL:phTask= "); }
+                            relativeUrl = placeholderTask.getUrl();
                         }
                         if ((relativeUrl == null || relativeUrl.equals("")) && item != null) {
                             if (cbDebug) { msgLine.append(" URL:item= "); }


### PR DESCRIPTION
This builds on top of #20 to add two things:
* lowest-level basic support for pipelines - the `pom.xml` dependencies needed for it, in a manner that should be merge-compatible with my other open PRs (regarding whitespace cleanup in this XML file)
* interaction with `org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution.PlaceholderTask` in `bot/CurrentlyBuildingCommand.java` to properly extract the build's URL from a running pipeline subtask.

Due to the first point, this PR is filed separately.