### PR TITLE
Support sending an instant customMessage to IM targets as a build step

### DIFF
--- a/src/main/java/hudson/plugins/im/build_notify/ExtraMessageOnlyBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/ExtraMessageOnlyBuildToChatNotifier.java
@@ -17,7 +17,9 @@ import static hudson.plugins.im.tools.BuildHelper.getProjectName;
 //import static hudson.plugins.im.tools.BuildHelper.isFix;
 
 /**
- * {@link BuildToChatNotifier} that skips status and everything except extraMessage.
+ * {@link BuildToChatNotifier} that skips status and everything except
+ * the extraMessage (and project/build identification data) while handling
+ * the Start and Completion event notifications of a build.
  * This is probably most useful as a pipeline step.
  *
  */
@@ -29,7 +31,7 @@ public class ExtraMessageOnlyBuildToChatNotifier extends BuildToChatNotifier {
     @Override
     public String buildStartMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
         return Messages.ExtraMessageOnlyBuildToChatNotifier_StartMessage(
-                build.getDisplayName(),getProjectName(build), publisher.getExtraMessage());
+                build.getDisplayName(), getProjectName(build), publisher.getExtraMessage());
     }
 
     @Override

--- a/src/main/java/hudson/plugins/im/config/ParameterNames.java
+++ b/src/main/java/hudson/plugins/im/config/ParameterNames.java
@@ -21,6 +21,12 @@ public abstract class ParameterNames {
         return getPrefix() + "extraMessage";
     }
 
+    // Note: This is not currently exposed in freestyle jobs,
+    // but was added here for consistency
+    public String getCustomMessage() {
+        return getPrefix() + "customMessage";
+    }
+
     public String getNotifySuspects() {
         return getPrefix() + "notifySuspects";
     }


### PR DESCRIPTION
Move into common IM plugin foundations the idea from https://github.com/jenkinsci/ircbot-plugin/pull/21 and https://github.com/jenkinsci/ircbot-plugin/pull/21/commits/6b10c77c471d092ce76253663bc52954804f1201 specifically.

After some internal testing, the plan is to update that PR to match, and likely make a new release first to depend and build against.