### PR TITLE
Support notifyStart in pipeline steps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
             <version>2.7</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,10 @@
         </pluginManagement>
     </build>
 
+    <properties>
+        <java.level>8</java.level>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/im/IMPublisher.java
+++ b/src/main/java/hudson/plugins/im/IMPublisher.java
@@ -355,16 +355,10 @@ public abstract class IMPublisher extends Notifier implements BuildStep, MatrixA
                     notifyOnBuildEnd(run, taskListener);
                 }
             } else {
-                if (run instanceof AbstractBuild
-                        && run.getParent() instanceof WorkflowJob
-                        && getNotifyOnStart()
-                        && taskListener instanceof BuildListener
-                ) {
+                if (run.getParent() instanceof WorkflowJob && getNotifyOnStart()) {
                     // part of a pipeline step, called with the option explicitly
                     // (has no other way to do so at the moment, no options{} support)
-                    AbstractBuild currentBuild = (AbstractBuild) run;
-                    BuildListener currentBuildListener = (BuildListener) taskListener;
-                    notifyChatsOnBuildStart(currentBuild, currentBuildListener);
+                    notifyChatsOnBuildStart(run, taskListener);
                     return;
                 } // else fall through
                 notifyOnBuildEnd(run, taskListener);

--- a/src/main/java/hudson/plugins/im/IMPublisher.java
+++ b/src/main/java/hudson/plugins/im/IMPublisher.java
@@ -68,6 +68,15 @@ public abstract class IMPublisher extends Notifier implements BuildStep, MatrixA
     private hudson.plugins.jabber.NotificationStrategy notificationStrategy;
 
     private NotificationStrategy strategy;
+    // Note: the name evolved over time, in notification-strategy.jelly it is
+    // published as 'notifyOnStart' and in Parameters.java (for paramNames)
+    // also as 'notifyStart', while older constructor named it
+    // 'notifyGroupChatsOnBuildStart'.
+    // The getter for this is 'getNotifyOnStart()', while the action taken in
+    // practice is 'notifyChatsOnBuildStart()'.
+    // Indeed, naming is one of the fundamental problems in IT ;)
+    // Following the getter, protocol plugins that expose this as a toggle for
+    // pipeline steps are encouraged to name their argument 'notifyOnStart'.
     private final boolean notifyOnBuildStart;
     private final boolean notifySuspects;
     private final boolean notifyCulprits;

--- a/src/main/java/hudson/plugins/im/IMPublisher.java
+++ b/src/main/java/hudson/plugins/im/IMPublisher.java
@@ -688,7 +688,11 @@ public abstract class IMPublisher extends Notifier implements BuildStep, MatrixA
      * @throws IOException
      */
     /* package for testing */ void notifyChatsOnBuildStart(AbstractBuild<?, ?> build, BuildListener buildListener) throws IOException, InterruptedException {
-        final String msg = buildToChatNotifier.buildStartMessage(this,build,buildListener);
+        this.notifyChatsOnBuildStart( (Run<?, ?>)build, (TaskListener) buildListener );
+    }
+
+    /* package for testing */ void notifyChatsOnBuildStart(@Nonnull Run<?, ?> build, @Nonnull TaskListener buildListener) throws IOException, InterruptedException {
+        final String msg = getBuildToChatNotifier().buildStartMessage(this, build, buildListener);
         if (Util.fixEmpty(msg) == null) {
             return;
         }

--- a/src/main/java/hudson/plugins/im/build_notify/BuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/BuildToChatNotifier.java
@@ -34,6 +34,8 @@ public abstract class BuildToChatNotifier implements Describable<BuildToChatNoti
     public abstract String buildStartMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener)
             throws IOException,  InterruptedException;
 
+    public abstract String buildStartMessage(IMPublisher publisher, Run<?, ?> build, TaskListener listener)
+            throws IOException,  InterruptedException;
 
     /**
      * Calculates the message to send out to a chat when the specified build is completed.

--- a/src/main/java/hudson/plugins/im/build_notify/DefaultBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/DefaultBuildToChatNotifier.java
@@ -29,16 +29,21 @@ public class DefaultBuildToChatNotifier extends SummaryOnlyBuildToChatNotifier {
 
     @Override
     public String buildStartMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
+        return this.buildStartMessage(publisher, (Run<?, ?>) build, (TaskListener) listener);
+    }
+
+    @Override
+    public String buildStartMessage(IMPublisher publisher, Run<?, ?> build, TaskListener listener) throws IOException, InterruptedException {
         StringBuilder sb = new StringBuilder(super.buildStartMessage(publisher, build, listener));
 
-        AbstractBuild<?, ?> previousBuild = build.getPreviousBuild();
+        Run<?, ?> previousBuild = build.getPreviousBuild();
         if (previousBuild != null && !previousBuild.isBuilding()) {
             sb.append(" (previous build: ")
                 .append(getResultTrend(previousBuild).getID());
 
             Result r = previousBuild.getResult();
             if (r == null || r.isWorseThan(Result.SUCCESS)) {
-                AbstractBuild<?, ?> lastSuccessfulBuild = build.getPreviousSuccessfulBuild();
+                Run<?, ?> lastSuccessfulBuild = build.getPreviousSuccessfulBuild();
                 if (lastSuccessfulBuild != null) {
                     sb.append(" -- last ").append(Result.SUCCESS).append(" ")
                         .append(lastSuccessfulBuild.getDisplayName())

--- a/src/main/java/hudson/plugins/im/build_notify/ExtraMessageOnlyBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/ExtraMessageOnlyBuildToChatNotifier.java
@@ -30,6 +30,11 @@ public class ExtraMessageOnlyBuildToChatNotifier extends BuildToChatNotifier {
 
     @Override
     public String buildStartMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
+        return this.buildStartMessage(publisher, (Run<?, ?>) build, (TaskListener) listener);
+    }
+
+    @Override
+    public String buildStartMessage(IMPublisher publisher, Run<?, ?> build, TaskListener listener) throws IOException, InterruptedException {
         return Messages.ExtraMessageOnlyBuildToChatNotifier_StartMessage(
                 build.getDisplayName(), getProjectName(build), publisher.getExtraMessage());
     }

--- a/src/main/java/hudson/plugins/im/build_notify/ExtraMessageOnlyBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/ExtraMessageOnlyBuildToChatNotifier.java
@@ -17,7 +17,9 @@ import static hudson.plugins.im.tools.BuildHelper.getProjectName;
 //import static hudson.plugins.im.tools.BuildHelper.isFix;
 
 /**
- * {@link BuildToChatNotifier} that skips status and everything except extraMessage.
+ * {@link BuildToChatNotifier} that skips status and everything except
+ * the extraMessage (and project/build identification data) while handling
+ * the Start and Completion event notifications of a build.
  * This is probably most useful as a pipeline step.
  *
  */
@@ -29,7 +31,7 @@ public class ExtraMessageOnlyBuildToChatNotifier extends BuildToChatNotifier {
     @Override
     public String buildStartMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
         return Messages.ExtraMessageOnlyBuildToChatNotifier_StartMessage(
-                build.getDisplayName(),getProjectName(build), publisher.getExtraMessage());
+                build.getDisplayName(), getProjectName(build), publisher.getExtraMessage());
     }
 
     @Override

--- a/src/main/java/hudson/plugins/im/build_notify/SummaryOnlyBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/SummaryOnlyBuildToChatNotifier.java
@@ -27,6 +27,11 @@ public class SummaryOnlyBuildToChatNotifier extends BuildToChatNotifier {
 
     @Override
     public String buildStartMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
+        return this.buildStartMessage(publisher, (Run<?, ?>) build, (TaskListener) listener);
+    }
+
+    @Override
+    public String buildStartMessage(IMPublisher publisher, Run<?, ?> build, TaskListener listener) throws IOException, InterruptedException {
         String extraMessage = publisher.getExtraMessage();
         if (extraMessage != null && !extraMessage.equals("")) {
             return Messages.SummaryOnlyBuildToChatNotifier_StartMessageExtra(build.getDisplayName(),getProjectName(build), extraMessage);

--- a/src/main/java/hudson/plugins/im/config/ParameterNames.java
+++ b/src/main/java/hudson/plugins/im/config/ParameterNames.java
@@ -21,6 +21,12 @@ public abstract class ParameterNames {
         return getPrefix() + "extraMessage";
     }
 
+    // Note: This is not currently exposed in freestyle jobs,
+    // but was added here for consistency
+    public String getCustomMessage() {
+        return getPrefix() + "customMessage";
+    }
+
     public String getNotifySuspects() {
         return getPrefix() + "notifySuspects";
     }

--- a/src/main/java/hudson/plugins/im/config/ParameterNames.java
+++ b/src/main/java/hudson/plugins/im/config/ParameterNames.java
@@ -13,6 +13,7 @@ public abstract class ParameterNames {
         return getPrefix() + "strategy";
     }
 
+    // Note: A pipeline step equivalent would be 'notifyOnStart'
     public String getNotifyStart() {
         return getPrefix() + "notifyStart";
     }


### PR DESCRIPTION
As commented, a better way probably would be to figure out how to support pipeline `options { ircNotify(...) }` (maybe even generalize later on to some `imNotify`, option as well as a common step to call whichever IM protocol(s) are configured?)

But for now, the problem to work around is that an `ircNotify` step in the middle of a job we just get a build-ended notification with a "NOT BUILT" status since there is no verdict yet. Hopefully the proposed hack will allow to handle that (testing internally...)