### PR TITLE
CurrentlyBuildingCommand.java: for bad args, PM the syntax to user…

### DIFF
--- a/src/main/java/hudson/plugins/im/bot/CurrentlyBuildingCommand.java
+++ b/src/main/java/hudson/plugins/im/bot/CurrentlyBuildingCommand.java
@@ -99,7 +99,7 @@ public class CurrentlyBuildingCommand extends BotCommand {
                     break argsloop;
                 default:
                     msg.append("\n- WARNING: got unsupported argument '" + args[a] + "' for currentlyBuilding, ignored; no filter was applied\n");
-                    if (cbDebug) { msg.append(giveSyntax(sender.getNickname(), args[0])); }
+                    msg.append(giveSyntax(sender.getNickname(), args[0]));
                     break;
             }
         }


### PR DESCRIPTION
…always (so it is highlighted and easier to notice)