### PR TITLE
Remove erroneous compatibleSinceVersion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,6 @@
                     <loggers>
                         <hudson.plugins.im>FINE</hudson.plugins.im>
                     </loggers>
-                    <compatibleSinceVersion>2.0</compatibleSinceVersion>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
The `compatibleSinceVersion` seemed to have been mistakenly introduced by copy pasting the config from Lockable Resources in [this commit](https://github.com/jenkinsci/instant-messaging-plugin/commit/1a4d42bdc1acca4f7dce7c6c8734f0119bb4967f). This causes a warning when in the update center whenever there is a new version available (since version 2.0 is superior to the current release line).

<img width="2559" alt="warning-uc" src="https://user-images.githubusercontent.com/6858329/140838431-1c690f59-e958-492c-9ec0-f53e68ad000a.png">

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue