### PR TITLE
pom.xml: bump jenkins.version to a newer LTS as needed by newer deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <java.level>8</java.level>
         <jenkins.version>2.332.1</jenkins.version>
+        <!-- Note: keep in sync with io.jenkins.tools.bom version below -->
     </properties>
 
     <dependencyManagement>
@@ -88,7 +89,7 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <!-- needs hudson.model.User with getById() -->
+            <!-- needs version of hudson.model.User with getById() -->
             <version>3.19</version>
             <exclusions>
                 <!-- TODO bump in maven plugin, conflict with junit plugin dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -60,18 +60,6 @@
             <version>1.5.6</version>
         </dependency>
         <dependency>
-            <groupId>org.kohsuke</groupId>
-            <artifactId>access-modifier-annotation</artifactId>
-            <scope>provided</scope>
-            <!-- Use version preferred by jenkins-core -->
-        </dependency>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <scope>provided</scope>
-            <!-- Use version preferred by jenkins-core -->
-        </dependency>
-        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,6 @@
             <!-- TODO: should be transformed into a optional dependency -->
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>javax.mail-api</artifactId>
-            <version>1.5.6</version>
-        </dependency>
-        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
         <revision>1.50</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <java.level>8</java.level>
         <jenkins.version>2.332.1</jenkins.version>
         <!-- Note: keep in sync with io.jenkins.tools.bom version below -->
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -32,15 +32,15 @@
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <java.level>8</java.level>
-        <jenkins.version>2.289.1</jenkins.version>
+        <jenkins.version>2.332.1</jenkins.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.263.x</artifactId>
-                <version>961.vf0c9f6f59827</version>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1500.ve4d05cd32975</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -52,6 +52,28 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
             <!-- TODO: should be transformed into a optional dependency -->
+        </dependency>
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>javax.mail-api</artifactId>
+            <version>1.5.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>access-modifier-annotation</artifactId>
+            <scope>provided</scope>
+            <!-- Use version preferred by jenkins-core -->
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+            <!-- Use version preferred by jenkins-core -->
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -67,7 +89,7 @@
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
             <!-- needs hudson.model.User with getById() -->
-            <version>3.16</version>
+            <version>3.19</version>
             <exclusions>
                 <!-- TODO bump in maven plugin, conflict with junit plugin dependencies -->
                 <exclusion>
@@ -81,6 +103,11 @@
                 <exclusion>
                     <groupId>commons-net</groupId>
                     <artifactId>commons-net</artifactId>
+                </exclusion>
+                <!-- Provided by Jenkins core -->
+                <exclusion>
+                    <groupId>org.jenkins-ci</groupId>
+                    <artifactId>symbol-annotation</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,11 +59,6 @@
             <!-- TODO: should be transformed into a optional dependency -->
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <!-- Preferred version is constrained above in dependencyManagement -->
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
             <!-- TODO: should be transformed into a optional dependency -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.29</version>
+        <version>4.43.1</version>
         <relativePath />
     </parent>
 
@@ -139,6 +139,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>3.12.4</version>
+            <!-- Note: mockito 4.x removed the Matchers class,
+                 which was Deprecated in 3.x and is currently
+                 used in MatrixNotificationTest sources
+            -->
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,11 +122,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.4</version>
-            <!-- Note: mockito 4.x removed the Matchers class,
-                 which was Deprecated in 3.x and is currently
-                 used in MatrixNotificationTest sources
-            -->
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -57,7 +62,7 @@
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
+            <!-- Preferred version is constrained above in dependencyManagement -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,10 +69,6 @@
             <artifactId>matrix-project</artifactId>
             <!-- TODO: should be transformed into a optional dependency -->
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>

--- a/src/test/java/hudson/plugins/im/IMPublisherTest.java
+++ b/src/test/java/hudson/plugins/im/IMPublisherTest.java
@@ -25,8 +25,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import javax.mail.MessagingException;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -149,7 +147,8 @@ public class IMPublisherTest {
      * list.
      */
     @Test
-    public void testIncludeUpstreamCulprits() throws MessagingException, InterruptedException {
+    public void testIncludeUpstreamCulprits() throws Exception {
+        /* Anticipating javax.mail.MessagingException and InterruptedException */
         Set<User> recipients = this.imPublisher.getNearestUpstreamCommitters(this.build, listener).keySet();
 
         assertEquals(recipients.toString(), 2, recipients.size());

--- a/src/test/java/hudson/plugins/im/MatrixNotificationTest.java
+++ b/src/test/java/hudson/plugins/im/MatrixNotificationTest.java
@@ -14,7 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
Maintenance bump inspired by (build failure of) #90 : 

````
[ERROR] Failed to execute goal org.jenkins-ci.tools:maven-hpi-plugin:3.19:validate-hpi (default-validate-hpi)
    on project instant-messaging: Dependency org.jenkins-ci.main:maven-plugin:jar:3.19 requires Jenkins 2.332.1 or higher. -> [Help 1]
````

Closes: #90