### PR TITLE
Remove unneeded `commons-lang` dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,11 +112,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
This is already provided by Jenkins core, so no need to bundle it in the plugin HPI.