### PR TITLE
Removed 4 unnecessary stubbings in BuildCommandTest.java

### DIFF
--- a/src/test/java/hudson/plugins/im/bot/BuildCommandTest.java
+++ b/src/test/java/hudson/plugins/im/bot/BuildCommandTest.java
@@ -98,7 +98,7 @@ public class BuildCommandTest {
         JobProvider jobProvider = mock(JobProvider.class);
         cmd.setJobProvider(jobProvider);
 
-        AbstractProject<?, ?> project = mockProject(jobProvider);
+        AbstractProject<?, ?> project = mockProject2(jobProvider);
         project = mockProject(jobProvider);
         when(project.isParameterized()).thenReturn(Boolean.TRUE);
         when(project.getProperty(ParametersDefinitionProperty.class)).thenReturn(
@@ -194,18 +194,30 @@ public class BuildCommandTest {
     @Test
     public void disabledProjectShouldNotBeScheduled() {
         Bot bot = mock(Bot.class);
-        when(bot.getImId()).thenReturn("hudsonbot");
-
         BuildCommand cmd = new BuildCommand();
         JobProvider jobProvider = mock(JobProvider.class);
         cmd.setJobProvider(jobProvider);
 
-        AbstractProject<?, ?> project = mockProject(jobProvider);
+        AbstractProject<?, ?> project = mockProject3(jobProvider);
         when(project.isBuildable()).thenReturn(false);
 
         Sender sender = new Sender("sender");
         cmd.getReply(bot, sender, new String[]{"build", "project"});
 
         verify(project, times(0)).scheduleBuild(anyInt(), any(Cause.class));
+    }
+
+    private AbstractProject<?, ?> mockProject2(JobProvider jobProvider) {
+        @SuppressWarnings("rawtypes")
+        AbstractProject project = mock(FreeStyleProject.class);
+        return project;
+    }
+
+    private AbstractProject<?, ?> mockProject3(JobProvider jobProvider) {
+        @SuppressWarnings("rawtypes")
+        AbstractProject project = mock(FreeStyleProject.class);
+        when(jobProvider.getJobByNameOrDisplayName(Mockito.anyString())).thenReturn(project);
+        when(project.hasPermission(Item.BUILD)).thenReturn(Boolean.TRUE);
+        return project;
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
In our analysis of the project, we observed that 

1) the test BuildCommandTest.disabledProjectShouldNotBeScheduled contains 1 unnecessary stubbing;

2) 2 unnecessary stubbings which stubbed `getJobByNameOrDisplayName` method, `hasPermission` method are created but never executed by one method call in the test `BuildCommandTest.parametersFromCommandShouldBePassedToBuild`;

3) 1 unnecessary stubbing which stubbed `isBuildable` method is created but never executed by 2 tests `BuildCommandTest.disabledProjectShouldNotBeScheduled`, `BuildCommandTest.parametersFromCommandShouldBePassedToBuild`;

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).

We propose below a solution to remove the unnecessary stubbing.