### PR TITLE
Removed 15 unnecessary stubbings in IMPublisherTest.java

### DIFF
--- a/src/test/java/hudson/plugins/im/IMPublisherTest.java
+++ b/src/test/java/hudson/plugins/im/IMPublisherTest.java
@@ -61,25 +61,14 @@ public class IMPublisherTest {
         this.imPublisher = new IMTestPublisher();
 
         this.upstreamProject = mock(AbstractProject.class);
-        when(this.upstreamProject.toString()).thenReturn("mock.upstreamProject");
-
         this.project = mock(AbstractProject.class);
-        when(this.project.toString()).thenReturn("mock.project");
-        when(project.getScm()).thenReturn(new NullSCM());
-
         this.rangeset = RangeSet.fromString(buildNumber + "-" + (buildNumber + 2), false);
 
         this.previousBuildUpstreamBuild = mock(AbstractBuild.class);
-        when(this.previousBuildUpstreamBuild.toString()).thenReturn("mock.previousBuildUpstreamBuild");
-        when(this.previousBuildUpstreamBuild.getProject()).thenReturn(this.project); // Seems required since https://github.com/jenkinsci/instant-messaging-plugin/pull/171 bump
-        when(this.previousBuildUpstreamBuild.getParent()).thenReturn(this.project);  // => should pop out in AbstractBuild.getProject()
-
         this.upstreamBuildBetweenPreviousAndCurrent = mock(AbstractBuild.class);
-        when(this.upstreamBuildBetweenPreviousAndCurrent.toString()).thenReturn("mock.upstreamBuildBetweenPreviousAndCurrent");
         when(this.upstreamBuildBetweenPreviousAndCurrent.getDownstreamRelationship(this.project)).thenReturn(this.rangeset);
 
         this.upstreamBuild = mock(AbstractBuild.class);
-        when(this.upstreamBuild.toString()).thenReturn("mock.upstreamBuild");
         when(this.upstreamBuild.getDownstreamRelationship(this.project)).thenReturn(this.rangeset);
 
         createPreviousNextRelationShip(this.previousBuildUpstreamBuild, this.upstreamBuildBetweenPreviousAndCurrent,
@@ -87,11 +76,8 @@ public class IMPublisherTest {
 
 
         User user1 = mock(User.class);
-        when(user1.toString()).thenReturn("User1");
         ChangeLogSet<TestEntry> changeLogSet1 = new TestChangeLogSet(this.previousBuildUpstreamBuild,
                 new TestEntry(user1));
-        when(this.previousBuildUpstreamBuild.getChangeSet()).thenReturn(changeLogSet1);
-
         User user2 = mock(User.class);
         when(user2.toString()).thenReturn("User2");
         ChangeLogSet<TestEntry> changeLogSet2 = new TestChangeLogSet(this.upstreamBuildBetweenPreviousAndCurrent,
@@ -106,12 +92,10 @@ public class IMPublisherTest {
 
 
         this.previousBuild = mock(AbstractBuild.class);
-        when(this.previousBuild.toString()).thenReturn("mock.previousBuild");
         when(this.previousBuild.getResult()).thenReturn(Result.SUCCESS);
         when(this.previousBuild.getUpstreamRelationshipBuild(this.upstreamProject)).thenReturn(this.previousBuildUpstreamBuild);
 
         this.build = mock(AbstractBuild.class);
-        when(this.build.toString()).thenReturn("mock.build");
         when(this.build.getResult()).thenReturn(Result.FAILURE);
         when(this.build.getUpstreamRelationshipBuild(this.upstreamProject)).thenReturn(this.upstreamBuild);
         Map<AbstractProject, Integer> upstreamBuilds = Maps.newHashMap();
@@ -121,10 +105,9 @@ public class IMPublisherTest {
         when(this.build.getParent()).thenReturn(this.project);  // => should pop out in AbstractBuild.getProject()
         when(this.build.getNumber()).thenReturn(this.buildNumber);
 
-        createPreviousNextRelationShip(this.previousBuild, this.build);
+        createPreviousNextRelationShip2(this.previousBuild, this.build);
 
         this.listener = mock(BuildListener.class);
-        when(this.listener.getLogger()).thenReturn(System.out);
     }
 
     /**
@@ -147,7 +130,6 @@ public class IMPublisherTest {
 
         for (int i = builds.length - 1; i >= 0; i--) {
             if (i >= 1) {
-                when(builds[i].getPreviousBuild()).thenReturn(builds[i-1]);
             }
         }
     }
@@ -246,6 +228,22 @@ public class IMPublisherTest {
         @Override
         public boolean isEmptySet() {
             return false;
+        }
+    }
+    private static void createPreviousNextRelationShip2(AbstractBuild... builds) {
+        int max = builds.length - 1;
+        AbstractBuild previousSuccessful = null;
+        for (int i = 0; i < builds.length; i++) {
+            if (builds[i].getResult() == Result.SUCCESS) {
+                previousSuccessful = builds[i];
+            }
+            if (i < max) {
+                when(builds[i + 1].getPreviousSuccessfulBuild()).thenReturn(previousSuccessful);
+            }
+        }
+        for (int i = builds.length - 1; i >= 0; i--) {
+            if (i >= 1) {
+            }
         }
     }
 }

--- a/src/test/java/hudson/plugins/im/IMPublisherTest.java
+++ b/src/test/java/hudson/plugins/im/IMPublisherTest.java
@@ -230,6 +230,7 @@ public class IMPublisherTest {
             return false;
         }
     }
+
     private static void createPreviousNextRelationShip2(AbstractBuild... builds) {
         int max = builds.length - 1;
         AbstractBuild previousSuccessful = null;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

In our analysis of the project, we observed that 

1) 13 stubbings are created but never executed in `IMPublisherTest.before`

2) 1 stubbing which stubbed `getPreviousBuild` method is created but never executed in the method `IMPublisherTest.createPreviousNextRelationShip`;

3) 1 stubbing which stubbed `getNextBuild` method in  `NotificationStrategyTest.createPreviousNextRelationShip` is created but never executed by one method call in `IMPublisherTest.before`;

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).

We propose below a solution to remove the unnecessary stubbing.
