### PR TITLE
IMConnectionProvider.java: getAuthenticationHolder(): fix check for Bot user name…

### DIFF
--- a/src/main/java/hudson/plugins/im/IMConnectionProvider.java
+++ b/src/main/java/hudson/plugins/im/IMConnectionProvider.java
@@ -8,7 +8,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
+//import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 /**
  * Abstract implementation of a provider of {@link IMConnection}s.
@@ -115,9 +118,15 @@ public abstract class IMConnectionProvider implements IMConnectionListener {
     // we need an additional level of indirection to the Authentication entity
     // to fix HUDSON-5978 and HUDSON-5233
     public synchronized AuthenticationHolder getAuthenticationHolder() {
-        if (descriptor == null || descriptor.getHudsonUserName() == null
-            || descriptor.getHudsonUserName().isBlank()
-        ) {
+        if (descriptor == null || descriptor.getHudsonUserName() == null) {
+            return null;
+        }
+
+        if (descriptor.getHudsonUserName().isBlank()) {
+            if (Jenkins.getInstance().isUseSecurity()) {
+                throw new UsernameNotFoundException(
+                    "No local Jenkins user name is configured for instant messaging to act as");
+            }
             return null;
         }
 
@@ -130,9 +139,15 @@ public abstract class IMConnectionProvider implements IMConnectionListener {
 
                 // New spotbugs UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR
                 // just can't be quiesced, so duplicating the sanity-check here
-                if (descriptor == null || descriptor.getHudsonUserName() == null
-                    || descriptor.getHudsonUserName().isBlank()
-                ) {
+                if (descriptor == null || descriptor.getHudsonUserName() == null) {
+                    return null;
+                }
+
+                if (descriptor.getHudsonUserName().isBlank()) {
+                    if (Jenkins.getInstance().isUseSecurity()) {
+                        throw new UsernameNotFoundException(
+                            "No local Jenkins user name is configured for instant messaging to act as");
+                    }
                     return null;
                 }
 

--- a/src/main/java/hudson/plugins/im/IMConnectionProvider.java
+++ b/src/main/java/hudson/plugins/im/IMConnectionProvider.java
@@ -115,7 +115,9 @@ public abstract class IMConnectionProvider implements IMConnectionListener {
     // we need an additional level of indirection to the Authentication entity
     // to fix HUDSON-5978 and HUDSON-5233
     public synchronized AuthenticationHolder getAuthenticationHolder() {
-        if (descriptor == null || descriptor.getHudsonUserName() == null) {
+        if (descriptor == null || descriptor.getHudsonUserName() == null
+            || descriptor.getHudsonUserName().isBlank()
+        ) {
             return null;
         }
 
@@ -128,7 +130,9 @@ public abstract class IMConnectionProvider implements IMConnectionListener {
 
                 // New spotbugs UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR
                 // just can't be quiesced, so duplicating the sanity-check here
-                if (descriptor == null || descriptor.getHudsonUserName() == null) {
+                if (descriptor == null || descriptor.getHudsonUserName() == null
+                    || descriptor.getHudsonUserName().isBlank()
+                ) {
                     return null;
                 }
 


### PR DESCRIPTION
…to exempt empty strings (lack of specific configuration) [JENKINS-72590]

Per https://issues.jenkins.io/browse/JENKINS-72590 the check was insufficient - it only excluded `null` values, but an empty saved config conveys an empty non-null String instead.

### Testing done

Stumbled on this while dev-testing other PRs, and the temporary Jenkins controller had just a trivial configuration to log into IRC but only had an admin user defined locally. Replies from Jenkins for commands which required authorization, such as "help", failed with inability to "impersonate" and did not make it to IRC.

With this change, replies are present in a private chat and commands are honoured.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

UPDATE: Probably this is counter-productive after all: can't assign permission constraints to a non-existing user. Would change to a more reasonable exception that helps troubleshooting instead.