### PR TITLE
pom.xml: make Maven integration plugin optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
             <artifactId>maven-plugin</artifactId>
             <!-- needs version of hudson.model.User with getById() -->
             <version>3.23</version>
+            <optional>true</optional>
             <exclusions>
                 <!-- TODO bump in maven plugin, conflict with junit plugin dependencies -->
                 <exclusion>


### PR DESCRIPTION
maven-plugin has been added as a dependency with 30ca89104bb along with jenkins-war 2.3 and jenkins-core 2.3 and I guess it was no more bundled in Jenkins as a result.

The only usage is in hudson.plugins.im.bot.HealthCommandTest, otherwhise instant messaging does not depend on the plugin, it merely supports it.

Make the Maven plugin optional, this allows administrators to remove the plugin when it is otherwise not used.

**Note:** given the Maven plugin is only needed for testing the integration, my guess is that it should also be marked with `<scope>test</scope>`?

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
