### PR TITLE
HealthCommandTest.java : restore tests

### DIFF
--- a/src/test/java/hudson/plugins/im/bot/HealthCommandTest.java
+++ b/src/test/java/hudson/plugins/im/bot/HealthCommandTest.java
@@ -9,7 +9,6 @@ import hudson.plugins.im.Sender;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -43,7 +42,6 @@ public class HealthCommandTest {
 
     @SuppressWarnings("rawtypes")
     @Test
-    @Ignore("Needs rewriting to not use mockito")
     public void testHealth() throws Exception {
 
         FreeStyleBuild build = mock(FreeStyleBuild.class);
@@ -56,7 +54,6 @@ public class HealthCommandTest {
         AbstractMavenProject job = mock(AbstractMavenProject.class);
         ItemGroup parent = mock(ItemGroup.class);
         when(parent.getFullDisplayName()).thenReturn("");
-        when(job.getParent()).thenReturn(parent);
         when(job.getFullDisplayName()).thenReturn("fsProject");
         when(job.getLastBuild()).thenReturn(build);
         when(job.getBuildHealth()).thenReturn(healthMock);
@@ -74,7 +71,6 @@ public class HealthCommandTest {
 
     @SuppressWarnings("rawtypes")
     @Test
-    @Ignore("Needs rewriting to not use mockito")
     public void testFailure() throws Exception {
         FreeStyleBuild build = mock(FreeStyleBuild.class);
         when(build.getUrl()).thenReturn("job/foo/32/");
@@ -86,7 +82,6 @@ public class HealthCommandTest {
         AbstractMavenProject job = mock(AbstractMavenProject.class);
         ItemGroup parent = mock(ItemGroup.class);
         when(parent.getFullDisplayName()).thenReturn("");
-        when(job.getParent()).thenReturn(parent);
         when(job.getFullDisplayName()).thenReturn("fsProject");
         when(job.getLastBuild()).thenReturn(build);
         when(job.getBuildHealth()).thenReturn(healthMock);


### PR DESCRIPTION
Two of the HealthCommandTest tests were ignored due to a mismatch in the return value:

  HealthCommandTest.testFailure:87 WrongTypeOfReturnValue
  ItemGroup$MockitoMock$pmDFnSAx cannot be returned by getParent()
  getParent() should return Jenkins

The mock returns an ItemGroup when Mockito expects it to be Jenkins instance. 70244952bc84d updated the parent pom which I guess updated Mockito to a version that is stricter and check the returned value types and the author went to ignore the tests.

The mocked getParent() method does not need to be mocked for the tests to pass, thus remove the mocks and restore the tests.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
